### PR TITLE
[Composer] Add post-root-package-install copy commands for Data example files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,15 @@
   "scripts"           : {
     "post-root-package-install"                   : [
       "php -r \"file_exists('app/src/App/Http/Config.php') || copy('app/src/App/Http/Config.example.php', 'app/src/App/Http/Config.php');\"",
-      "php -r \"file_exists('app/src/App/Cli/Config.php') || copy('app/src/App/Cli/Config.example.php', 'app/src/App/Cli/Config.php');\""
+      "php -r \"file_exists('app/src/App/Cli/Config.php') || copy('app/src/App/Cli/Config.example.php', 'app/src/App/Cli/Config.php');\"",
+      "php -r \"file_exists('app/src/App/Http/Data/AppContainerData.php') || copy('app/src/App/Http/Data/AppContainerData.example.php', 'app/src/App/Http/Data/AppContainerData.php');\"",
+      "php -r \"file_exists('app/src/App/Http/Data/AppEventData.php') || copy('app/src/App/Http/Data/AppEventData.example.php', 'app/src/App/Http/Data/AppEventData.php');\"",
+      "php -r \"file_exists('app/src/App/Http/Data/AppHttpRoutingData.php') || copy('app/src/App/Http/Data/AppHttpRoutingData.example.php', 'app/src/App/Http/Data/AppHttpRoutingData.php');\"",
+      "php -r \"file_exists('app/src/App/Cli/Data/AppContainerData.php') || copy('app/src/App/Cli/Data/AppContainerData.example.php', 'app/src/App/Cli/Data/AppContainerData.php');\"",
+      "php -r \"file_exists('app/src/App/Cli/Data/AppEventData.php') || copy('app/src/App/Cli/Data/AppEventData.example.php', 'app/src/App/Cli/Data/AppEventData.php');\"",
+      "php -r \"file_exists('app/src/App/Cli/Data/AppCliRoutingData.php') || copy('app/src/App/Cli/Data/AppCliRoutingData.example.php', 'app/src/App/Cli/Data/AppCliRoutingData.php');\"",
+      "php -r \"file_exists('app/src/App/Cli/Data/AppHttpRoutingData.php') || copy('app/src/App/Cli/Data/AppHttpRoutingData.example.php', 'app/src/App/Cli/Data/AppHttpRoutingData.php');\""
+
     ],
     "phparkitect"                                 : "cd .github/ci/phparkitect && composer check",
     "phparkitect-outdated-check"                  : "cd .github/ci/phparkitect && composer install && composer outdated --direct --minor-only",


### PR DESCRIPTION
# Description

Extend the post-root-package-install composer script to copy Data example files into place alongside the existing Config copies. Without these commands, a fresh `composer create-project` install would be missing the required Data files and fail at runtime.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`composer.json`** — added post-root-package-install copy commands to initialise Data files from their `.example.php` counterparts if not already present:
    - `app/src/App/Http/Data/AppContainerData.php`
    - `app/src/App/Http/Data/AppEventData.php`
    - `app/src/App/Http/Data/AppHttpRoutingData.php`
    - `app/src/App/Cli/Data/AppContainerData.php`
    - `app/src/App/Cli/Data/AppEventData.php`
    - `app/src/App/Cli/Data/AppCliRoutingData.php`
    - `app/src/App/Cli/Data/AppHttpRoutingData.php`