### PR TITLE
[Documentation] Rewrite README for starter app repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,107 +2,215 @@
     <img src="https://raw.githubusercontent.com/valkyrjaio/art/refs/heads/master/long-banner/orange/php.png" width="100%">
 </a></p>
 
-# Valkyrja
+# Valkyrja Starter (App)
 
-[Valkyrja][Valkyrja url] is a PHP framework for web and console applications.
+Starter template for building PHP applications on the
+[Valkyrja][Valkyrja url] framework.
 
-About Valkyrja
-------------
-
-> This repository contains the skeleton code of an application built with the
-> Valkyrja framework.
-
-Valkyrja (pronounced "Valk-ear-ya") is the Old Norse spelling for Valkyrie, a
-mythical creature that would guide warriors to Valhalla (the afterlife and a
-better place) after death. In a similar sense, the Valkyrja framework guides
-your application to be in a better state. Let this fast, light, and robust
-framework do the heavy lifting for your app.
+This repository gives you a working Valkyrja application as a starting point —
+HTTP and CLI kernels pre-wired, example controllers and commands, configuration
+scaffolding, and a ready-to-customize `App/` namespace. The starter passes the
+same linting, static analysis, and architectural rules as the Valkyrja
+framework itself, so you can focus on building your application rather than
+cleaning up the foundation.
 
 <p>
     <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/require/php" alt="PHP Version Require"></a>
     <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/v" alt="Latest Stable Version"></a>
     <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/license" alt="License"></a>
-    <!-- <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/downloads" alt="Total Downloads"></a>-->
-    <a href="https://scrutinizer-ci.com/g/valkyrjaio/application/?branch=26.x"><img src="https://scrutinizer-ci.com/g/valkyrjaio/application/badges/quality-score.png?b=26.x" alt="Scrutinizer"></a>
-    <!-- <a href="https://coveralls.io/github/valkyrjaio/application?branch=26.x"><img src="https://coveralls.io/repos/github/valkyrjaio/application/badge.svg?branch=26.x" alt="Coverage Status" /></a> -->
-    <a href="https://shepherd.dev/github/valkyrjaio/application"><img src="https://shepherd.dev/github/valkyrjaio/application/coverage.svg" alt="Psalm Shepherd" /></a>
-    <a href="https://sonarcloud.io/summary/new_code?id=valkyrjaio_application"><img src="https://sonarcloud.io/api/project_badges/measure?project=valkyrjaio_application&metric=sqale_rating" alt="Maintainability Rating" /></a>
+    <a href="https://github.com/valkyrjaio/valkyrja-starter-app-php/actions/workflows/ci.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/valkyrja-starter-app-php/actions/workflows/ci.yml/badge.svg?branch=26.x" alt="CI Status"></a>
+    <a href="https://scrutinizer-ci.com/g/valkyrjaio/valkyrja-starter-app-php/?branch=26.x"><img src="https://scrutinizer-ci.com/g/valkyrjaio/valkyrja-starter-app-php/badges/quality-score.png?b=26.x" alt="Scrutinizer"></a>
+    <a href="https://shepherd.dev/github/valkyrjaio/valkyrja-starter-app-php"><img src="https://shepherd.dev/github/valkyrjaio/valkyrja-starter-app-php/coverage.svg" alt="Psalm Shepherd"></a>
+    <a href="https://sonarcloud.io/summary/new_code?id=valkyrjaio_valkyrja-starter-app-php"><img src="https://sonarcloud.io/api/project_badges/measure?project=valkyrjaio_valkyrja-starter-app-php&metric=sqale_rating" alt="Maintainability Rating" /></a>
 </p>
 
-Build Status
-------------
+What's in the Box
+-----------------
 
-<table>
-    <tbody>
-        <tr>
-            <td>Linting</td>
-            <td>
-                <a href="https://github.com/valkyrjaio/application/actions/workflows/phpcodesniffer.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/application/actions/workflows/phpcodesniffer.yml/badge.svg?branch=26.x" alt="PHP Code Sniffer Build Status"></a>
-            </td>
-            <td>
-                <a href="https://github.com/valkyrjaio/application/actions/workflows/phpcsfixer.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/application/actions/workflows/phpcsfixer.yml/badge.svg?branch=26.x" alt="PHP CS Fixer Build Status"></a>
-            </td>
-        </tr>
-        <tr>
-            <td>Coding Rules</td>
-            <td>
-                <a href="https://github.com/valkyrjaio/application/actions/workflows/phparkitect.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/application/actions/workflows/phparkitect.yml/badge.svg?branch=26.x" alt="PHPArkitect Build Status"></a>
-            </td>
-            <td>
-                <a href="https://github.com/valkyrjaio/application/actions/workflows/rector.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/application/actions/workflows/rector.yml/badge.svg?branch=26.x" alt="Rector Build Status"></a>
-            </td>
-        </tr>
-        <tr>
-            <td>Static Analysis</td>
-            <td>
-                <a href="https://github.com/valkyrjaio/application/actions/workflows/phpstan.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/application/actions/workflows/phpstan.yml/badge.svg?branch=26.x" alt="PHPStan Build Status"></a>
-            </td>
-            <td>
-                <a href="https://github.com/valkyrjaio/application/actions/workflows/psalm.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/application/actions/workflows/psalm.yml/badge.svg?branch=26.x" alt="Psalm Build Status"></a>
-            </td>
-        </tr>
-        <tr>
-            <td>Testing</td>
-            <td>
-                <a href="https://github.com/valkyrjaio/application/actions/workflows/phpunit.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/application/actions/workflows/phpunit.yml/badge.svg?branch=26.x" alt="PHPUnit Build Status"></a>
-            </td>
-            <td></td>
-        </tr>
-    </tbody>
-</table>
+- **Pre-wired HTTP and CLI kernels** — the application boots and responds to
+  both web requests and command-line invocations out of the box
+- **Example controllers and commands** — working code showing typical routing,
+  request handling, and command dispatch patterns
+- **Configuration scaffolding** — `Config/` and `Data/` layers with example
+  files and environment-driven overrides
+- **Testing setup** — PHPUnit configured with example tests and the same
+  structure used across Valkyrja's own components
+- **Full CI pipeline** — PHPStan, Psalm, PHPCodeSniffer, PHP CS Fixer,
+  PHPArkitect, and Rector all configured and passing on a clean clone
+- **Docker support** _(optional)_ — via
+  [`valkyrja-docker-php`][docker url] for containerized development and
+  deployment
+- **Worker runtime integrations** _(optional)_ — OpenSwoole, FrankenPHP, or
+  RoadRunner for persistent-worker deployments
 
 Installation
 ------------
 
-### Clone this repo locally.
+### Use this template _(recommended)_
 
-```
-git clone git@github.com:valkyrjaio/application.git ./your-project
-cd your-project
-composer install
-```
+This repository is a GitHub template. Click the **Use this template** button
+at the top of the repo to create a new repository in your own account,
+pre-populated with the starter code.
 
-### Install via composer
+### Via Composer
 
 ```
 composer create-project valkyrja/application your-project
+cd your-project
 ```
 
-### Start coding
+### Clone manually _(for contributing to the starter itself)_
 
-You're now able to start coding your application. Feel free to remove any
-code that you don't need from this skeleton. All of this code exists as an
-example. Read the documentation if you need to know how to do something
-specific and don't yet know how to do it.
+```
+git clone git@github.com:valkyrjaio/valkyrja-starter-app-php.git
+cd valkyrja-starter-app-php
+composer install
+```
+
+Getting Started
+---------------
+
+### Project Structure
+
+The key directories you'll work in:
+
+```
+app/
+├── src/
+│   └── App/           # your application code lives here
+│       ├── Cli/       # CLI commands, providers, and configuration
+│       └── Http/      # HTTP controllers, providers, and configuration
+├── bootstrap/         # application entry points (HTTP and CLI)
+├── config/            # environment and runtime configuration
+└── tests/             # your test suite
+```
+
+Your application code goes in the `App\` namespace under `app/src/App/`. The
+starter provides example HTTP controllers and CLI commands you can study,
+modify, or replace.
+
+### Running Your Application
+
+**HTTP (built-in PHP server):**
+
+```
+php -S localhost:8080 -t bootstrap/http
+```
+
+Navigate to `http://localhost:8080` to see the example routes.
+
+**CLI:**
+
+```
+php bootstrap/cli/valkyrja
+```
+
+Run with no arguments to see the list of available commands.
+
+### Writing Code
+
+**Adding a route:** see the example controller in `app/src/App/Http/Controller/`
+and the route definitions it registers. For the full routing API, see the
+[Valkyrja HTTP documentation][http docs url].
+
+**Adding a command:** see the example command in `app/src/App/Cli/Command/`.
+For the full CLI API, see the
+[Valkyrja CLI documentation][cli docs url].
+
+**Binding services:** the dependency injection container is configured in the
+`Provider` classes under each `App/` subdirectory. See the
+[Valkyrja container documentation][container docs url] for the full API.
+
+### Running Tests
+
+```
+composer phpunit
+```
+
+For coverage:
+
+```
+composer phpunit-coverage
+```
+
+### Running CI Checks Locally
+
+The starter ships with the same CI pipeline as the Valkyrja framework. Run
+any check via its composer script:
+
+```
+composer phpstan
+composer psalm
+composer phpcodesniffer
+composer phpcsfixer
+composer phparkitect
+composer rector
+```
+
+Deployment
+----------
+
+The starter runs on any PHP 8.4+ environment. For production, Valkyrja
+supports several persistent-worker runtimes for significantly better
+performance than traditional PHP-FPM:
+
+- [**OpenSwoole**][openswoole url] — persistent worker via the OpenSwoole
+  extension
+- [**FrankenPHP**][frankenphp url] — persistent worker via the FrankenPHP
+  embedded runtime
+- [**RoadRunner**][roadrunner url] — persistent worker via the Go-based
+  RoadRunner manager
+
+See each integration's README for setup instructions specific to that runtime.
+For containerized deployment, [`valkyrja-docker-php`][docker url] provides
+ready-made Docker configurations.
 
 Documentation
 -------------
 
-The Valkyrja [documentation][docs url] is baked into the repo so you can
-access it even when working offline.
+Full Valkyrja documentation lives in the [framework repository][docs url] and
+is baked into the source tree so you can browse it offline.
+
+For starter-specific questions, open an issue on this repository. For
+framework questions, open an issue on the
+[Valkyrja framework repository][framework url].
+
+Contributing
+------------
+
+Contributions to the starter itself — improvements to the example code,
+bug fixes, CI improvements — are welcome. See
+[`CONTRIBUTING.md`][contributing url] for the submission process and
+[`VOCABULARY.md`][vocabulary url] for the terminology used across Valkyrja.
+
+License
+-------
+
+The Valkyrja framework and this starter are open-source software licensed
+under the [MIT license][MIT license url]. See [`LICENSE.md`](./LICENSE.md).
 
 [Valkyrja url]: https://valkyrja.io
 
-[Valkyrja Application url]: https://github.com/valkyrjaio/application
+[framework url]: https://github.com/valkyrjaio/valkyrja-php
 
-[docs url]: https://github.com/valkyrjaio/valkyrja/tree/26.x/src/Valkyrja/README.md
+[docker url]: https://github.com/valkyrjaio/valkyrja-docker-php
+
+[openswoole url]: https://github.com/valkyrjaio/valkyrja-openswoole-php
+
+[frankenphp url]: https://github.com/valkyrjaio/valkyrja-frankenphp-php
+
+[roadrunner url]: https://github.com/valkyrjaio/valkyrja-roadrunner-php
+
+[docs url]: https://github.com/valkyrjaio/valkyrja-php/tree/26.x/src/Valkyrja/README.md
+
+[http docs url]: https://github.com/valkyrjaio/valkyrja-php/tree/26.x/src/Valkyrja/Http/README.md
+
+[cli docs url]: https://github.com/valkyrjaio/valkyrja-php/tree/26.x/src/Valkyrja/Cli/README.md
+
+[container docs url]: https://github.com/valkyrjaio/valkyrja-php/tree/26.x/src/Valkyrja/Container/README.md
+
+[contributing url]: https://github.com/valkyrjaio/.github/blob/master/CONTRIBUTING.md
+
+[vocabulary url]: https://github.com/valkyrjaio/.github/blob/master/VOCABULARY.md
+
+[MIT license url]: https://opensource.org/licenses/MIT


### PR DESCRIPTION
# Description

Rewrite the `README.md` for the starter app repo to match the repo's actual purpose and align with the recent renames and vocabulary standardization.

The previous README was largely copied from the framework repo's README and pitched Valkyrja itself rather than describing the starter. It also referenced the old `valkyrjaio/application` repo name throughout, contained a "skeleton" term now deprecated in favor of "starter," and missed the information a new user actually needs — what's in the box, how to run it, and where to go next.

The rewrite keeps the visual signals users care about (quality badges conveying that the starter is as clean as the framework) while trimming content that belonged in the framework README, updating all URLs to the renamed repo, adding sections for project structure, running the application, and deployment runtime options, and cross-linking to the new `CONTRIBUTING.md` and `VOCABULARY.md` in `.github`.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [X] Documentation improvement

## Changes

- **`README.md`**
    - Retitled to "Valkyrja Starter (App)" reflecting the repo's specific identity within the starter family
    - Replaced the framework pitch with a starter-focused lead and a quality-guarantee sentence justifying the badge cluster
    - Updated all URLs from `valkyrjaio/application` to `valkyrjaio/valkyrja-starter-app-php` across badges, clone commands, and action references
    - Updated the framework repo URL from `valkyrjaio/valkyrja` to `valkyrjaio/valkyrja-php`
    - Collapsed the six-cell Build Status table into a single `CI` badge in the main badge row, aligned with the consolidated `ci.yml` workflow
    - Added a "What's in the Box" section listing concrete deliverables (pre-wired kernels, example controllers and commands, config scaffolding, CI pipeline, optional Docker and runtime integrations)
    - Reordered the Installation section: "Use this template" first as the primary path, Composer `create-project` second, manual clone last and flagged as contributor-only
    - Added a "Getting Started" section with project structure, commands for running HTTP and CLI locally, guidance on writing routes/commands/service bindings with inline links to framework docs, and test/CI commands
    - Added a "Deployment" section pointing at the OpenSwoole, FrankenPHP, RoadRunner, and Docker integrations
    - Added a "Contributing" section cross-linking to `CONTRIBUTING.md` and `VOCABULARY.md` in `.github`
    - Replaced all instances of "skeleton" with "starter" per `VOCABULARY.md`