### PR TITLE
[App] Simplify Config constructors and fix package header

### DIFF
--- a/app/src/App/Cli/Config.example.php
+++ b/app/src/App/Cli/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Cli/Config.example.php
+++ b/app/src/App/Cli/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -18,64 +18,33 @@ namespace App\Cli;
 use App\Cli\Provider\ComponentProvider;
 use App\Http\Config as AppHttpConfig;
 use Valkyrja\Application\Data\CliConfig;
-use Valkyrja\Application\Data\HttpConfig;
-use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Application\Provider\CliWithHttpApplicationComponentProvider;
-use Valkyrja\Application\Provider\Contract\ComponentProviderContract;
 use Valkyrja\Cli\Server\Constant\CommandName;
 
 final class Config extends CliConfig
 {
-    /**
-     * @param non-empty-string                          $namespace
-     * @param non-empty-string                          $dir
-     * @param non-empty-string                          $version
-     * @param non-empty-string                          $environment
-     * @param non-empty-string                          $timezone
-     * @param non-empty-string                          $key
-     * @param non-empty-string                          $dataPath
-     * @param non-empty-string                          $dataNamespace
-     * @param non-empty-string                          $applicationName
-     * @param non-empty-string                          $defaultCommandName
-     * @param class-string<ComponentProviderContract>[] $providers
-     * @param array<callable(ApplicationContract):void> $callbacks
-     */
-    public function __construct(
-        string $namespace = 'App',
-        string $dir = __DIR__ . '/../../..',
-        string $version = '1.0.0',
-        string $environment = 'production',
-        bool $debugMode = true,
-        string $timezone = 'UTC',
-        string $key = 'some_secret_app_key',
-        string $dataPath = 'App/Cli/Data',
-        string $dataNamespace = 'App\\Cli\\Data',
-        string $applicationName = 'cli',
-        string $defaultCommandName = CommandName::LIST,
-        array $providers = [
-            CliWithHttpApplicationComponentProvider::class,
-            ComponentProvider::class,
-        ],
-        array $callbacks = [
-            [ComponentProvider::class, 'publish'],
-        ],
-        HttpConfig $http = new AppHttpConfig(),
-    ) {
+    public function __construct()
+    {
         parent::__construct(
-            namespace: $namespace,
-            dir: $dir,
-            version: $version,
-            environment: $environment,
-            debugMode: $debugMode,
-            timezone: $timezone,
-            key: $key,
-            dataPath: $dataPath,
-            dataNamespace: $dataNamespace,
-            applicationName: $applicationName,
-            defaultCommandName: $defaultCommandName,
-            providers: $providers,
-            callbacks: $callbacks,
-            http: $http,
+            namespace: 'App',
+            dir: __DIR__ . '/../../..',
+            version: '1.0.0',
+            environment: 'production',
+            debugMode: true,
+            timezone: 'UTC',
+            key: 'some_secret_app_key',
+            dataPath: 'App/Cli/Data',
+            dataNamespace: 'App\\Cli\\Data',
+            applicationName: 'cli',
+            defaultCommandName: CommandName::LIST,
+            providers: [
+                CliWithHttpApplicationComponentProvider::class,
+                ComponentProvider::class,
+            ],
+            callbacks: [
+                [ComponentProvider::class, 'publish'],
+            ],
+            http: new AppHttpConfig(),
         );
     }
 }

--- a/app/src/App/Http/Config.example.php
+++ b/app/src/App/Http/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Http/Config.example.php
+++ b/app/src/App/Http/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -17,79 +17,33 @@ namespace App\Http;
 
 use App\Http\Provider\ComponentProvider;
 use Valkyrja\Application\Data\HttpConfig;
-use Valkyrja\Application\Kernel\Contract\ApplicationContract;
-use Valkyrja\Application\Provider\Contract\ComponentProviderContract;
 use Valkyrja\Application\Provider\HttpApplicationComponentProvider;
-use Valkyrja\Http\Middleware\Contract\RequestReceivedMiddlewareContract;
-use Valkyrja\Http\Middleware\Contract\RouteDispatchedMiddlewareContract;
-use Valkyrja\Http\Middleware\Contract\RouteMatchedMiddlewareContract;
-use Valkyrja\Http\Middleware\Contract\RouteNotMatchedMiddlewareContract;
-use Valkyrja\Http\Middleware\Contract\SendingResponseMiddlewareContract;
-use Valkyrja\Http\Middleware\Contract\TerminatedMiddlewareContract;
-use Valkyrja\Http\Middleware\Contract\ThrowableCaughtMiddlewareContract;
-use Valkyrja\Http\Middleware\Data\Contract\ConfigContract;
 use Valkyrja\Http\Server\Middleware\CacheResponseMiddleware;
 
-final class Config extends HttpConfig implements ConfigContract
+final class Config extends HttpConfig
 {
-    /**
-     * @param non-empty-string                                  $namespace
-     * @param non-empty-string                                  $dir
-     * @param non-empty-string                                  $version
-     * @param non-empty-string                                  $environment
-     * @param non-empty-string                                  $timezone
-     * @param non-empty-string                                  $key
-     * @param non-empty-string                                  $dataPath
-     * @param non-empty-string                                  $dataNamespace
-     * @param class-string<ComponentProviderContract>[]         $providers
-     * @param array<callable(ApplicationContract):void>         $callbacks
-     * @param class-string<RequestReceivedMiddlewareContract>[] $requestReceivedMiddleware
-     * @param class-string<RouteMatchedMiddlewareContract>[]    $routeMatchedMiddleware
-     * @param class-string<RouteNotMatchedMiddlewareContract>[] $routeNotMatchedMiddleware
-     * @param class-string<RouteDispatchedMiddlewareContract>[] $routeDispatchedMiddleware
-     * @param class-string<ThrowableCaughtMiddlewareContract>[] $throwableCaughtMiddleware
-     * @param class-string<SendingResponseMiddlewareContract>[] $sendingResponseMiddleware
-     * @param class-string<TerminatedMiddlewareContract>[]      $terminatedMiddleware
-     */
-    public function __construct(
-        string $namespace = 'App',
-        string $dir = __DIR__ . '/../../..',
-        string $version = '1.0.0',
-        string $environment = 'production',
-        bool $debugMode = true,
-        string $timezone = 'UTC',
-        string $key = 'some_secret_app_key',
-        string $dataPath = 'App/Http/Data',
-        string $dataNamespace = 'App\\Http\\Data',
-        array $providers = [
-            HttpApplicationComponentProvider::class,
-            ComponentProvider::class,
-        ],
-        array $callbacks = [
-            [ComponentProvider::class, 'publish'],
-        ],
-        public array $requestReceivedMiddleware = [
-            CacheResponseMiddleware::class,
-        ],
-        public array $routeMatchedMiddleware = [],
-        public array $routeNotMatchedMiddleware = [],
-        public array $routeDispatchedMiddleware = [],
-        public array $throwableCaughtMiddleware = [],
-        public array $sendingResponseMiddleware = [],
-        public array $terminatedMiddleware = [],
-    ) {
+    public function __construct()
+    {
         parent::__construct(
-            namespace: $namespace,
-            dir: $dir,
-            version: $version,
-            environment: $environment,
-            debugMode: $debugMode,
-            timezone: $timezone,
-            key: $key,
-            dataPath: $dataPath,
-            dataNamespace: $dataNamespace,
-            providers: $providers,
-            callbacks: $callbacks,
+            namespace: 'App',
+            dir: __DIR__ . '/../../..',
+            version: '1.0.0',
+            environment: 'production',
+            debugMode: true,
+            timezone: 'UTC',
+            key: 'some_secret_app_key',
+            dataPath: 'App/Http/Data',
+            dataNamespace: 'App\\Http\\Data',
+            providers: [
+                HttpApplicationComponentProvider::class,
+                ComponentProvider::class,
+            ],
+            callbacks: [
+                [ComponentProvider::class, 'publish'],
+            ],
+            requestReceivedMiddleware: [
+                CacheResponseMiddleware::class,
+            ],
         );
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -377,12 +377,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja.git",
-                "reference": "24f965ac2abbf4415084c09527eccae4d168dda6"
+                "reference": "df59fd48820079c1f8220b9bb0e4be9bab869512"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja/zipball/24f965ac2abbf4415084c09527eccae4d168dda6",
-                "reference": "24f965ac2abbf4415084c09527eccae4d168dda6",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja/zipball/df59fd48820079c1f8220b9bb0e4be9bab869512",
+                "reference": "df59fd48820079c1f8220b9bb0e4be9bab869512",
                 "shasum": ""
             },
             "require": {
@@ -547,7 +547,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "valkyrja/valkyrja": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
# Description

Simplifies the `App\Cli\Config` and `App\Http\Config` constructors by removing the explicit parameter re-declarations and passing defaults directly to `parent::__construct()`. Also removes the now-unnecessary `ConfigContract` implementation from `Http\Config` and corrects the file header package name.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`app/src/App/Cli/Config.example.php`**
    - Simplified constructor
    - Removed redundant parameter declarations
    - Fixed package header
- **`app/src/App/Http/Config.example.php`**
    - Simplified constructor
    - Removed redundant parameter declarations and unused imports
    - Dropped `ConfigContract` implementation
    - Fixed package header