### PR TITLE
[Composer] Add valkyrja/sindri dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
   "require"           : {
     "php"               : ">=8.4",
     "monolog/monolog"   : "^3.10.0",
-    "valkyrja/sindri"   : "^26.0.0",
     "valkyrja/valkyrja" : "^26.1.0"
   },
   "require-dev"       : {
-    "filp/whoops" : "^2.18.4"
+    "filp/whoops"     : "^2.18.4",
+    "valkyrja/sindri" : "^26.0.0"
   },
   "config"            : {
     "optimize-autoloader" : true,

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,11 @@
   "require"           : {
     "php"               : ">=8.4",
     "monolog/monolog"   : "^3.10.0",
+    "valkyrja/sindri"   : "^26.0.0",
     "valkyrja/valkyrja" : "^26.1.0"
   },
   "require-dev"       : {
-    "filp/whoops"     : "^2.18.4"
+    "filp/whoops" : "^2.18.4"
   },
   "config"            : {
     "optimize-autoloader" : true,
@@ -42,7 +43,6 @@
       "php -r \"file_exists('app/src/App/Cli/Data/AppEventData.php') || copy('app/src/App/Cli/Data/AppEventData.example.php', 'app/src/App/Cli/Data/AppEventData.php');\"",
       "php -r \"file_exists('app/src/App/Cli/Data/AppCliRoutingData.php') || copy('app/src/App/Cli/Data/AppCliRoutingData.example.php', 'app/src/App/Cli/Data/AppCliRoutingData.php');\"",
       "php -r \"file_exists('app/src/App/Cli/Data/AppHttpRoutingData.php') || copy('app/src/App/Cli/Data/AppHttpRoutingData.example.php', 'app/src/App/Cli/Data/AppHttpRoutingData.php');\""
-
     ],
     "phparkitect"                                 : "cd .github/ci/phparkitect && composer check",
     "phparkitect-outdated-check"                  : "cd .github/ci/phparkitect && composer install && composer outdated --direct --minor-only",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9b20737d8adb73f1455a7c2bb207c13",
+    "content-hash": "64b1a01d6a9fe4c427a7aa3e29dfdf5d",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -108,6 +108,64 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "psr/container",
@@ -372,17 +430,69 @@
             "time": "2024-09-11T13:17:53+00:00"
         },
         {
+            "name": "valkyrja/sindri",
+            "version": "26.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/valkyrjaio/sindri-php.git",
+                "reference": "415a948ac7aa3ef28c7252ec852f4a162f4f3968"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/415a948ac7aa3ef28c7252ec852f4a162f4f3968",
+                "reference": "415a948ac7aa3ef28c7252ec852f4a162f4f3968",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.4",
+                "valkyrja/valkyrja": "26.x-dev"
+            },
+            "default-branch": true,
+            "bin": [
+                "bin/sindri"
+            ],
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "Sindri\\": "src/Sindri"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Melech Mizrachi",
+                    "email": "melechmizrachi@gmail.com"
+                }
+            ],
+            "description": "The Valkyrja Sindri build tool.",
+            "homepage": "https://www.valkyrja.io/sindri",
+            "keywords": [
+                "build tool",
+                "sindri",
+                "valkyrja"
+            ],
+            "support": {
+                "issues": "https://github.com/valkyrjaio/sindri-php/issues",
+                "source": "https://github.com/valkyrjaio/sindri-php/tree/26.x"
+            },
+            "time": "2026-04-20T02:37:28+00:00"
+        },
+        {
             "name": "valkyrja/valkyrja",
             "version": "26.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja.git",
-                "reference": "df59fd48820079c1f8220b9bb0e4be9bab869512"
+                "reference": "e3429a4daa597bbbda6955f8d0c2bc34e32c37ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja/zipball/df59fd48820079c1f8220b9bb0e4be9bab869512",
-                "reference": "df59fd48820079c1f8220b9bb0e4be9bab869512",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja/zipball/e3429a4daa597bbbda6955f8d0c2bc34e32c37ae",
+                "reference": "e3429a4daa597bbbda6955f8d0c2bc34e32c37ae",
                 "shasum": ""
             },
             "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64b1a01d6a9fe4c427a7aa3e29dfdf5d",
+    "content-hash": "975c46df9aa6469b852646f8db5db306",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -657,9 +657,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "valkyrja/valkyrja": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -110,64 +110,6 @@
             "time": "2026-01-02T08:56:05+00:00"
         },
         {
-            "name": "nikic/php-parser",
-            "version": "v5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
-            },
-            "time": "2025-12-06T11:56:16+00:00"
-        },
-        {
             "name": "psr/container",
             "version": "2.0.2",
             "source": {
@@ -430,58 +372,6 @@
             "time": "2024-09-11T13:17:53+00:00"
         },
         {
-            "name": "valkyrja/sindri",
-            "version": "26.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/valkyrjaio/sindri-php.git",
-                "reference": "415a948ac7aa3ef28c7252ec852f4a162f4f3968"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/415a948ac7aa3ef28c7252ec852f4a162f4f3968",
-                "reference": "415a948ac7aa3ef28c7252ec852f4a162f4f3968",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.7.0",
-                "php": ">=8.4",
-                "valkyrja/valkyrja": "26.x-dev"
-            },
-            "default-branch": true,
-            "bin": [
-                "bin/sindri"
-            ],
-            "type": "project",
-            "autoload": {
-                "psr-4": {
-                    "Sindri\\": "src/Sindri"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Melech Mizrachi",
-                    "email": "melechmizrachi@gmail.com"
-                }
-            ],
-            "description": "The Valkyrja Sindri build tool.",
-            "homepage": "https://www.valkyrja.io/sindri",
-            "keywords": [
-                "build tool",
-                "sindri",
-                "valkyrja"
-            ],
-            "support": {
-                "issues": "https://github.com/valkyrjaio/sindri-php/issues",
-                "source": "https://github.com/valkyrjaio/sindri-php/tree/26.x"
-            },
-            "time": "2026-04-20T02:37:28+00:00"
-        },
-        {
             "name": "valkyrja/valkyrja",
             "version": "26.x-dev",
             "source": {
@@ -653,11 +543,123 @@
                 }
             ],
             "time": "2025-08-08T12:00:00+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "valkyrja/sindri",
+            "version": "26.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/valkyrjaio/sindri-php.git",
+                "reference": "415a948ac7aa3ef28c7252ec852f4a162f4f3968"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/415a948ac7aa3ef28c7252ec852f4a162f4f3968",
+                "reference": "415a948ac7aa3ef28c7252ec852f4a162f4f3968",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.4",
+                "valkyrja/valkyrja": "26.x-dev"
+            },
+            "default-branch": true,
+            "bin": [
+                "bin/sindri"
+            ],
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "Sindri\\": "src/Sindri"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Melech Mizrachi",
+                    "email": "melechmizrachi@gmail.com"
+                }
+            ],
+            "description": "The Valkyrja Sindri build tool.",
+            "homepage": "https://www.valkyrja.io/sindri",
+            "keywords": [
+                "build tool",
+                "sindri",
+                "valkyrja"
+            ],
+            "support": {
+                "issues": "https://github.com/valkyrjaio/sindri-php/issues",
+                "source": "https://github.com/valkyrjaio/sindri-php/tree/26.x"
+            },
+            "time": "2026-04-20T02:37:28+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "valkyrja/valkyrja": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
# Description

Adds `valkyrja/sindri` as a required dev dependency. Sindri is the Valkyrja build tool that generates cache files and provides other development utilities used during the build step of a Valkyrja application.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`composer.json`**
    - Added `valkyrja/sindri ^26.0.0` to `require-dev`
    - Removed trailing blank line in post-install scripts
- **`composer.lock`** — updated with `valkyrja/sindri` and its transitive dependency `nikic/php-parser ^5.7.0`