### PR TITLE
[Config] Fix data path to include src prefix for Sindri generation

### DIFF
--- a/app/src/App/Cli/Config.example.php
+++ b/app/src/App/Cli/Config.example.php
@@ -33,7 +33,7 @@ final class Config extends CliConfig
             debugMode: true,
             timezone: 'UTC',
             key: 'some_secret_app_key',
-            dataPath: 'App/Cli/Data',
+            dataPath: 'src/App/Cli/Data',
             dataNamespace: 'App\\Cli\\Data',
             applicationName: 'cli',
             defaultCommandName: CommandName::LIST,

--- a/app/src/App/Http/Config.example.php
+++ b/app/src/App/Http/Config.example.php
@@ -32,7 +32,7 @@ final class Config extends HttpConfig
             debugMode: true,
             timezone: 'UTC',
             key: 'some_secret_app_key',
-            dataPath: 'App/Http/Data',
+            dataPath: 'src/App/Http/Data',
             dataNamespace: 'App\\Http\\Data',
             providers: [
                 HttpApplicationComponentProvider::class,

--- a/app/src/App/Http/Data/.gitignore
+++ b/app/src/App/Http/Data/.gitignore
@@ -1,3 +1,4 @@
+AppCliRoutingData.php
 AppContainerData.php
 AppEventData.php
 AppHttpRoutingData.php


### PR DESCRIPTION
## Description

Fixes the `dataPath` values in both `Cli/Config.example.php` and `Http/Config.example.php` to include the `src/` prefix, matching the actual filesystem path that Sindri uses when writing generated data files. Also adds `AppCliRoutingData.php` to the HTTP `Data/.gitignore` to keep the ignore list consistent between the Cli and Http data directories.

---

## Types of Changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`app/src/App/Cli/Config.example.php`** — corrected `dataPath` from `App/Cli/Data` to `src/App/Cli/Data`
- **`app/src/App/Http/Config.example.php`** — corrected `dataPath` from `App/Http/Data` to `src/App/Http/Data`
- **`app/src/App/Http/Data/.gitignore`** — added `AppCliRoutingData.php` to match the Cli data gitignore