### PR TITLE
[Config] Remove deprecated `http` property in `CliConfig`

### DIFF
--- a/app/src/App/Cli/Config.example.php
+++ b/app/src/App/Cli/Config.example.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace App\Cli;
 
 use App\Cli\Provider\ComponentProvider;
-use App\Http\Config as AppHttpConfig;
 use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Application\Provider\CliWithHttpApplicationComponentProvider;
 use Valkyrja\Cli\Server\Constant\CommandName;
@@ -44,7 +43,6 @@ final class Config extends CliConfig
             callbacks: [
                 [ComponentProvider::class, 'publish'],
             ],
-            http: new AppHttpConfig(),
         );
     }
 }


### PR DESCRIPTION
# Description

Removes the deprecated `http` property from `App\Cli\Config.example.php`, dropping the `App\Http\Config` import and its instantiation in the `CliConfig` constructor call.

---

## Types of Changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`app/src/App/Cli/Config.example.php`** — removed `use App\Http\Config as AppHttpConfig` import and `http: new AppHttpConfig()` argument from the `CliConfig` constructor call