### PR TITLE
[Application] Update route handlers to accept RouteContract

### DIFF
--- a/app/src/App/Cli/Provider/RouteProvider.php
+++ b/app/src/App/Cli/Provider/RouteProvider.php
@@ -16,6 +16,7 @@ namespace App\Cli\Provider;
 use App\Cli\Command\TestCommand;
 use Override;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Provider\Contract\CliRouteProviderContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 
@@ -44,7 +45,7 @@ final class RouteProvider implements CliRouteProviderContract
     /**
      * The test command handler.
      */
-    public static function testCommandHandler(ContainerContract $container): OutputContract
+    public static function testCommandHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
         return $container->getSingleton(TestCommand::class)->run();
     }

--- a/app/src/App/Http/Provider/RouteProvider.php
+++ b/app/src/App/Http/Provider/RouteProvider.php
@@ -19,6 +19,7 @@ use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\Http\Routing\Data\Contract\DynamicRouteContract;
 use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Provider\Contract\HttpRouteProviderContract;
 use Valkyrja\View\Factory\Contract\ResponseFactoryContract as ViewResponseFactoryContract;
@@ -45,10 +46,7 @@ final class RouteProvider implements HttpRouteProviderContract
         return [];
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function versionHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function versionHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return HomeController::version(
             $container->getSingleton(ApplicationContract::class),
@@ -56,63 +54,48 @@ final class RouteProvider implements HttpRouteProviderContract
         );
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function textHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function textHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return HomeController::text();
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function welcomeHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function welcomeHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return $container->getSingleton(HomeController::class)->welcome(
             $container->getSingleton(ViewResponseFactoryContract::class),
         );
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function welcomeCachedHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function welcomeCachedHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return $container->getSingleton(HomeController::class)->welcomeCached(
             $container->getSingleton(ViewResponseFactoryContract::class),
         );
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function dynamicHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function dynamicHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
-        /** @var string $value */
-        $value = $arguments['value'] ?? 'default';
+        /**
+         * @var DynamicRouteContract $route
+         * @var string               $value
+         */
+        $value = $route->getParameter('value')->getValue();
 
         return $container->getSingleton(HomeController::class)->dynamic(
-            $container->getSingleton(RouteContract::class),
+            $route,
             $container->getSingleton(ViewResponseFactoryContract::class),
             $value
         );
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function homeHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function homeHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return $container->getSingleton(HomeController::class)->home(
             $container->getSingleton(ViewResponseFactoryContract::class),
         );
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function jsonHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function jsonHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return $container->getSingleton(HomeController::class)->json(
             $container->getSingleton(ResponseFactoryContract::class),

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev"       : {
     "filp/whoops"     : "^2.18.4",
-    "valkyrja/sindri" : "^26.0.0"
+    "valkyrja/sindri" : "^26.1.0"
   },
   "config"            : {
     "optimize-autoloader" : true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "975c46df9aa6469b852646f8db5db306",
+    "content-hash": "9192e3fea635c4571e95eb034866190b",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -377,12 +377,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja-php.git",
-                "reference": "c79de288fedf90cc708a91975b53abb40e22c8e0"
+                "reference": "aef033cde6b6dcf4214c48c1fd55c665401e36c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/c79de288fedf90cc708a91975b53abb40e22c8e0",
-                "reference": "c79de288fedf90cc708a91975b53abb40e22c8e0",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/aef033cde6b6dcf4214c48c1fd55c665401e36c0",
+                "reference": "aef033cde6b6dcf4214c48c1fd55c665401e36c0",
                 "shasum": ""
             },
             "require": {
@@ -466,7 +466,7 @@
                 "issues": "https://github.com/valkyrjaio/valkyrja-php/issues",
                 "source": "https://github.com/valkyrjaio/valkyrja-php/tree/26.x"
             },
-            "time": "2026-04-23T19:38:59+00:00"
+            "time": "2026-04-26T03:38:44+00:00"
         }
     ],
     "packages-dev": [
@@ -601,16 +601,16 @@
         },
         {
             "name": "valkyrja/sindri",
-            "version": "v26.0.0",
+            "version": "v26.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/sindri-php.git",
-                "reference": "b618a527cb48a1bc8fdd4ce3e12ba83b387a7ea2"
+                "reference": "42c90c25558049b059068b479a36964e6cda1d86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/b618a527cb48a1bc8fdd4ce3e12ba83b387a7ea2",
-                "reference": "b618a527cb48a1bc8fdd4ce3e12ba83b387a7ea2",
+                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/42c90c25558049b059068b479a36964e6cda1d86",
+                "reference": "42c90c25558049b059068b479a36964e6cda1d86",
                 "shasum": ""
             },
             "require": {
@@ -646,9 +646,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/sindri-php/issues",
-                "source": "https://github.com/valkyrjaio/sindri-php/tree/v26.0.0"
+                "source": "https://github.com/valkyrjaio/sindri-php/tree/v26.1.0"
             },
-            "time": "2026-04-24T04:47:28+00:00"
+            "time": "2026-04-26T04:18:46+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
# Description

Updates all route handler methods in both the HTTP and CLI route providers to accept a typed `RouteContract` (or `DynamicRouteContract`) parameter instead of an untyped `array $arguments`. Dynamic route parameters are now retrieved via the route object's typed API (`$route->getParameter('value')->getValue()`), and the redundant `$container->getSingleton(RouteContract::class)` call in `dynamicHandler` is removed in favour of the injected `$route` directly.

Bumps `valkyrja/sindri` from `^26.0.0` to `^26.1.0` to pull in the updated handler contract.

---

## Types of Changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`app/src/App/Cli/Provider/RouteProvider.php`** — added `RouteContract $route` parameter to `testCommandHandler`; added corresponding `use` import
- **`app/src/App/Http/Provider/RouteProvider.php`** — replaced `array $arguments` with `RouteContract $route` on all handler methods; removed now-unnecessary `@param` docblocks; updated `dynamicHandler` to fetch the `value` parameter via `$route->getParameter('value')->getValue()` and pass `$route` directly instead of resolving it from the container; added `DynamicRouteContract` import
- **`composer.json`** — bumped `valkyrja/sindri` constraint from `^26.0.0` to `^26.1.0`