### PR TITLE
[Application] Update View response factory import to use renamed ViewResponseFactory

### DIFF
--- a/app/src/App/Http/Controller/HomeController.php
+++ b/app/src/App/Http/Controller/HomeController.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Http/Controller/HomeController.php
+++ b/app/src/App/Http/Controller/HomeController.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -31,7 +31,7 @@ use Valkyrja\Http\Routing\Attribute\Route\RouteHandler;
 use Valkyrja\Http\Routing\Constant\Regex;
 use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Server\Middleware\CacheResponseMiddleware;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract as ViewResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 
 class HomeController extends Controller
 {

--- a/app/src/App/Http/Provider/RouteProvider.php
+++ b/app/src/App/Http/Provider/RouteProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Http/Provider/RouteProvider.php
+++ b/app/src/App/Http/Provider/RouteProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -22,7 +22,7 @@ use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
 use Valkyrja\Http\Routing\Data\Contract\DynamicRouteContract;
 use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Provider\Contract\HttpRouteProviderContract;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract as ViewResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 
 final class RouteProvider implements HttpRouteProviderContract
 {

--- a/composer.lock
+++ b/composer.lock
@@ -377,12 +377,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja-php.git",
-                "reference": "59d94729f32fca0ac5ef7b4fab197ec42c046367"
+                "reference": "6125890311e2f46279f2b5e023af4ebaae831b25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/59d94729f32fca0ac5ef7b4fab197ec42c046367",
-                "reference": "59d94729f32fca0ac5ef7b4fab197ec42c046367",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/6125890311e2f46279f2b5e023af4ebaae831b25",
+                "reference": "6125890311e2f46279f2b5e023af4ebaae831b25",
                 "shasum": ""
             },
             "require": {
@@ -399,7 +399,7 @@
                 "guzzlehttp/guzzle": "<7.10.0",
                 "league/flysystem": "<3.33.0",
                 "league/flysystem-aws-s3-v3": "<3.32.0",
-                "mailgun/mailgun-php": "<4.4.0",
+                "mailgun/mailgun-php": "<4.5.0",
                 "monolog/monolog": "<3.10.0",
                 "phpmailer/phpmailer": "<7.0.2",
                 "predis/predis": "<3.4.2",
@@ -413,7 +413,7 @@
                 "guzzlehttp/guzzle": "^7.10.0",
                 "league/flysystem": "^3.33.0",
                 "league/flysystem-aws-s3-v3": "^3.32.0",
-                "mailgun/mailgun-php": "^4.4.0",
+                "mailgun/mailgun-php": "^4.5.0",
                 "monolog/monolog": "^3.10.0",
                 "phpmailer/phpmailer": "^7.0.2",
                 "predis/predis": "^3.4.2",
@@ -431,7 +431,7 @@
                 "guzzlehttp/guzzle": "Required to use the default Client adapter (^7.10.0).",
                 "league/flysystem": "Required to use the default Filesystem adapter (^3.33.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the s3 Filesystem adapter (^3.32.0)",
-                "mailgun/mailgun-php": "Required to use the Mailgun Mail adapter (^4.4.0).",
+                "mailgun/mailgun-php": "Required to use the Mailgun Mail adapter (^4.5.0).",
                 "monolog/monolog": "Required to use the default Log adapter (^3.10.0).",
                 "phpmailer/phpmailer": "Required to use the default Mail adapter (^7.0.2).",
                 "predis/predis": "Required to use the Redis Cache store (^3.4.2).",
@@ -466,7 +466,7 @@
                 "issues": "https://github.com/valkyrjaio/valkyrja-php/issues",
                 "source": "https://github.com/valkyrjaio/valkyrja-php/tree/26.x"
             },
-            "time": "2026-04-28T17:23:10+00:00"
+            "time": "2026-05-05T22:08:08+00:00"
         }
     ],
     "packages-dev": [
@@ -653,9 +653,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "valkyrja/valkyra": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -653,7 +653,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "valkyrja/valkyra": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Description

Follow-up to the `[View]` rename of `ResponseFactoryContract` → `ViewResponseFactoryContract` in the framework. Both files were previously aliasing the old name (`use ResponseFactoryContract as ViewResponseFactoryContract`); they now import the correctly named contract directly. Also corrects the package name in the file headers from "Valkyrja Application" to "Valkyrja Framework".

---

## Types of Changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`app/src/App/Http/Controller/HomeController.php`** — replaced aliased import with direct `ViewResponseFactoryContract`; corrected package name in file header
- **`app/src/App/Http/Provider/RouteProvider.php`** — replaced aliased import with direct `ViewResponseFactoryContract`; corrected package name in file header