### PR TITLE
[Composer] Update valkyrja/sindri to v26.1.2 and lock valkyrja/valkyrja to v26.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev"       : {
     "filp/whoops"     : "^2.18.4",
-    "valkyrja/sindri" : "^26.1.1"
+    "valkyrja/sindri" : "^26.1.2"
   },
   "config"            : {
     "optimize-autoloader" : true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49e258491883ed73a273e4a8ea3b0929",
+    "content-hash": "fdf46d8341f66a48b0a905331e9b70c8",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -373,16 +373,16 @@
         },
         {
             "name": "valkyrja/valkyrja",
-            "version": "26.x-dev",
+            "version": "v26.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja-php.git",
-                "reference": "331f7df78d65afb7664b8181401f0b075e5a2f3d"
+                "reference": "e5308ee455e6b5c1bf2e876747f14d15abb43f7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/331f7df78d65afb7664b8181401f0b075e5a2f3d",
-                "reference": "331f7df78d65afb7664b8181401f0b075e5a2f3d",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/e5308ee455e6b5c1bf2e876747f14d15abb43f7a",
+                "reference": "e5308ee455e6b5c1bf2e876747f14d15abb43f7a",
                 "shasum": ""
             },
             "require": {
@@ -439,7 +439,6 @@
                 "twig/twig": "Required to use the Twig View engine (^3.24.0).",
                 "vonage/client-core": "Required to use the default SMS adapter (^4.13.0)."
             },
-            "default-branch": true,
             "type": "project",
             "autoload": {
                 "psr-4": {
@@ -464,9 +463,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/valkyrja-php/issues",
-                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/26.x"
+                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/v26.1.0"
             },
-            "time": "2026-05-06T00:43:32+00:00"
+            "time": "2026-05-05T23:13:44+00:00"
         }
     ],
     "packages-dev": [
@@ -601,22 +600,22 @@
         },
         {
             "name": "valkyrja/sindri",
-            "version": "v26.1.1",
+            "version": "v26.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/sindri-php.git",
-                "reference": "4d3dc723359db1f8212f0308bc65e0781dea1377"
+                "reference": "5057df2789e3c1111c3bb3439fa2792d8190c27f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/4d3dc723359db1f8212f0308bc65e0781dea1377",
-                "reference": "4d3dc723359db1f8212f0308bc65e0781dea1377",
+                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/5057df2789e3c1111c3bb3439fa2792d8190c27f",
+                "reference": "5057df2789e3c1111c3bb3439fa2792d8190c27f",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.4",
-                "valkyrja/valkyrja": "26.x-dev"
+                "valkyrja/valkyrja": "^26.1.0"
             },
             "bin": [
                 "bin/sindri"
@@ -646,9 +645,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/sindri-php/issues",
-                "source": "https://github.com/valkyrjaio/sindri-php/tree/v26.1.1"
+                "source": "https://github.com/valkyrjaio/sindri-php/tree/v26.1.2"
             },
-            "time": "2026-04-26T05:24:32+00:00"
+            "time": "2026-05-06T01:30:14+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
# Description

Updates `valkyrja/sindri` from `^26.1.1` to `^26.1.2`. The lock file also resolves `valkyrja/valkyrja` from the rolling `26.x-dev` dev branch to the stable `v26.1.0` tag (pulled in transitively through the updated sindri, which now requires `^26.1.0` instead of `26.x-dev`).

---

## Types of Changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`composer.json`** — updated `valkyrja/sindri` constraint from `^26.1.1` to `^26.1.2`
- **`composer.lock`** — locked `valkyrja/sindri` to `v26.1.2` (`5057df2`); resolved `valkyrja/valkyrja` to `v26.1.0` (`e5308ee`), removing the `default-branch` flag