### PR TITLE
[Cli] Add Header banner message class and update all commands to use it

### DIFF
--- a/.github/ci/phpcodesniffer/composer.json
+++ b/.github/ci/phpcodesniffer/composer.json
@@ -3,7 +3,7 @@
     "php" : ">=8.4"
   },
   "require-dev"       : {
-    "valkyrja/phpcodesniffer" : "^26.1.1"
+    "valkyrja/phpcodesniffer" : "^26.1.2"
   },
   "scripts"           : {
     "check"    : "vendor/bin/phpcs --standard=./ruleset.xml ../../../app/src -n && vendor/bin/phpcs --standard=./ruleset.xml ../../../app/tests -n -s",

--- a/.github/ci/phpcodesniffer/composer.lock
+++ b/.github/ci/phpcodesniffer/composer.lock
@@ -296,21 +296,21 @@
         },
         {
             "name": "valkyrja/phpcodesniffer",
-            "version": "v26.1.1",
+            "version": "v26.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/ci-phpcodesniffer-php.git",
-                "reference": "41eaf11b7713506377fbb4e83aebbca096792f49"
+                "reference": "09a173a12239c41b2d78f55ebbedf4767ebba5cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/ci-phpcodesniffer-php/zipball/41eaf11b7713506377fbb4e83aebbca096792f49",
-                "reference": "41eaf11b7713506377fbb4e83aebbca096792f49",
+                "url": "https://api.github.com/repos/valkyrjaio/ci-phpcodesniffer-php/zipball/09a173a12239c41b2d78f55ebbedf4767ebba5cd",
+                "reference": "09a173a12239c41b2d78f55ebbedf4767ebba5cd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "slevomat/coding-standard": "^8.28.1",
+                "slevomat/coding-standard": "^8.29.0",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
             "type": "project",
@@ -338,9 +338,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/ci-phpcodesniffer-php/issues",
-                "source": "https://github.com/valkyrjaio/ci-phpcodesniffer-php/tree/v26.1.1"
+                "source": "https://github.com/valkyrjaio/ci-phpcodesniffer-php/tree/v26.1.2"
             },
-            "time": "2026-04-17T05:20:07+00:00"
+            "time": "2026-05-07T16:11:52+00:00"
         }
     ],
     "aliases": [],

--- a/app/src/App/Cli/Command/TestCommand.php
+++ b/app/src/App/Cli/Command/TestCommand.php
@@ -59,10 +59,15 @@ class TestCommand extends Controller
     #[RouteHandler([RouteProvider::class, 'testCommandHandler'])]
     public function run(RouteContract $route): OutputContract
     {
+        /** @var string $namespace */
+        $namespace = $this->config->namespace;
+        /** @var string $version */
+        $version = $this->config->version;
+
         return $this->outputFactory
             ->createOutput()
             ->withAddedMessages(
-                new Header($this->config->namespace, $this->config->version, $route),
+                new Header($namespace, $version, $route),
             )
             ->withAddedMessages(
                 new NewLine(),

--- a/app/src/App/Cli/Command/TestCommand.php
+++ b/app/src/App/Cli/Command/TestCommand.php
@@ -15,22 +15,33 @@ namespace App\Cli\Command;
 
 use App\Cli\Controller\Abstract\Controller;
 use App\Cli\Provider\RouteProvider;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
+use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
 use Valkyrja\Cli\Interaction\Message\Answer;
-use Valkyrja\Cli\Interaction\Message\Banner;
 use Valkyrja\Cli\Interaction\Message\Contract\AnswerContract;
 use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
+use Valkyrja\Cli\Interaction\Message\Header;
 use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Message\NewLine;
 use Valkyrja\Cli\Interaction\Message\Question;
-use Valkyrja\Cli\Interaction\Message\SuccessMessage;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 
 class TestCommand extends Controller
 {
     protected const string YES_ANSWER = 'yes';
     protected const string NO_ANSWER  = 'no';
+
+    public function __construct(
+        InputContract $input,
+        OutputFactoryContract $outputFactory,
+        private readonly CliConfigContract $config,
+    ) {
+        parent::__construct($input, $outputFactory);
+    }
 
     /**
      * The help text.
@@ -46,12 +57,12 @@ class TestCommand extends Controller
         helpText: [self::class, 'help'],
     )]
     #[RouteHandler([RouteProvider::class, 'testCommandHandler'])]
-    public function run(): OutputContract
+    public function run(RouteContract $route): OutputContract
     {
         return $this->outputFactory
             ->createOutput()
             ->withAddedMessages(
-                new Banner(new SuccessMessage('This is a success banner.')),
+                new Header($this->config->namespace, $this->config->version, $route),
             )
             ->withAddedMessages(
                 new NewLine(),

--- a/app/src/App/Cli/Command/TestCommand.php
+++ b/app/src/App/Cli/Command/TestCommand.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -17,7 +17,6 @@ use App\Cli\Config;
 use App\Cli\Controller\Abstract\Controller;
 use App\Cli\Provider\RouteProvider;
 use Valkyrja\Application\Data\Contract\CliConfigContract;
-use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
 use Valkyrja\Cli\Interaction\Message\Answer;
 use Valkyrja\Cli\Interaction\Message\Contract\AnswerContract;
 use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
@@ -26,7 +25,6 @@ use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Message\NewLine;
 use Valkyrja\Cli\Interaction\Message\Question;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
-use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
@@ -35,14 +33,6 @@ class TestCommand extends Controller
 {
     protected const string YES_ANSWER = 'yes';
     protected const string NO_ANSWER  = 'no';
-
-    public function __construct(
-        InputContract $input,
-        OutputFactoryContract $outputFactory,
-        private readonly CliConfigContract $config,
-    ) {
-        parent::__construct($input, $outputFactory);
-    }
 
     /**
      * The help text.
@@ -58,11 +48,12 @@ class TestCommand extends Controller
         helpText: [self::class, 'help'],
     )]
     #[RouteHandler([RouteProvider::class, 'testCommandHandler'])]
-    public function run(RouteContract $route): OutputContract
+    public function run(RouteContract $route, CliConfigContract $config): OutputContract
     {
-        /** @var Config $config */
-        $config = $this->config;
-        /** @var string $namespace */
+        /**
+         * @var Config $config
+         * @var string $namespace
+         */
         $namespace = $config->namespace;
         /** @var string $version */
         $version = $config->version;

--- a/app/src/App/Cli/Command/TestCommand.php
+++ b/app/src/App/Cli/Command/TestCommand.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Cli\Command;
 
+use App\Cli\Config;
 use App\Cli\Controller\Abstract\Controller;
 use App\Cli\Provider\RouteProvider;
 use Valkyrja\Application\Data\Contract\CliConfigContract;
@@ -59,10 +60,12 @@ class TestCommand extends Controller
     #[RouteHandler([RouteProvider::class, 'testCommandHandler'])]
     public function run(RouteContract $route): OutputContract
     {
+        /** @var Config $config */
+        $config = $this->config;
         /** @var string $namespace */
-        $namespace = $this->config->namespace;
+        $namespace = $config->namespace;
         /** @var string $version */
-        $version = $this->config->version;
+        $version = $config->version;
 
         return $this->outputFactory
             ->createOutput()

--- a/app/src/App/Cli/Provider/RouteProvider.php
+++ b/app/src/App/Cli/Provider/RouteProvider.php
@@ -15,6 +15,7 @@ namespace App\Cli\Provider;
 
 use App\Cli\Command\TestCommand;
 use Override;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Provider\Contract\CliRouteProviderContract;
@@ -47,6 +48,9 @@ final class RouteProvider implements CliRouteProviderContract
      */
     public static function testCommandHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
-        return $container->getSingleton(TestCommand::class)->run($route);
+        return $container->getSingleton(TestCommand::class)->run(
+            $route,
+            $container->getSingleton(CliConfigContract::class),
+        );
     }
 }

--- a/app/src/App/Cli/Provider/RouteProvider.php
+++ b/app/src/App/Cli/Provider/RouteProvider.php
@@ -47,6 +47,6 @@ final class RouteProvider implements CliRouteProviderContract
      */
     public static function testCommandHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
-        return $container->getSingleton(TestCommand::class)->run();
+        return $container->getSingleton(TestCommand::class)->run($route);
     }
 }

--- a/app/src/App/Cli/Provider/ServiceProvider.php
+++ b/app/src/App/Cli/Provider/ServiceProvider.php
@@ -15,7 +15,6 @@ namespace App\Cli\Provider;
 
 use App\Cli\Command\TestCommand;
 use Override;
-use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
@@ -44,7 +43,6 @@ final class ServiceProvider implements ServiceProviderContract
             new TestCommand(
                 $container->getSingleton(InputContract::class),
                 $container->getSingleton(OutputFactoryContract::class),
-                $container->getSingleton(CliConfigContract::class),
             )
         );
     }

--- a/app/src/App/Cli/Provider/ServiceProvider.php
+++ b/app/src/App/Cli/Provider/ServiceProvider.php
@@ -15,6 +15,7 @@ namespace App\Cli\Provider;
 
 use App\Cli\Command\TestCommand;
 use Override;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
@@ -42,7 +43,8 @@ final class ServiceProvider implements ServiceProviderContract
             TestCommand::class,
             new TestCommand(
                 $container->getSingleton(InputContract::class),
-                $container->getSingleton(OutputFactoryContract::class)
+                $container->getSingleton(OutputFactoryContract::class),
+                $container->getSingleton(CliConfigContract::class),
             )
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require"           : {
     "php"               : ">=8.4",
     "monolog/monolog"   : "^3.10.0",
-    "valkyrja/valkyrja" : "^26.1.0"
+    "valkyrja/valkyrja" : "^26.2.0"
   },
   "require-dev"       : {
     "filp/whoops"     : "^2.18.4",

--- a/composer.lock
+++ b/composer.lock
@@ -373,16 +373,16 @@
         },
         {
             "name": "valkyrja/valkyrja",
-            "version": "v26.1.0",
+            "version": "v26.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja-php.git",
-                "reference": "e5308ee455e6b5c1bf2e876747f14d15abb43f7a"
+                "reference": "63daf963a2c6672101649efc63e52645f1d5cbe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/e5308ee455e6b5c1bf2e876747f14d15abb43f7a",
-                "reference": "e5308ee455e6b5c1bf2e876747f14d15abb43f7a",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/63daf963a2c6672101649efc63e52645f1d5cbe9",
+                "reference": "63daf963a2c6672101649efc63e52645f1d5cbe9",
                 "shasum": ""
             },
             "require": {
@@ -463,9 +463,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/valkyrja-php/issues",
-                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/v26.1.0"
+                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/v26.2.0"
             },
-            "time": "2026-05-05T23:13:44+00:00"
+            "time": "2026-05-07T21:44:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
# Description

Removes the now-redundant `App\Cli\Constant\CliHeader` and `App\Cli\Message\AppCliHeader` classes, replacing them with the framework's new `Valkyrja\Cli\Interaction\Message\Header` directly in `TestCommand`.

---

## Types of Changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`App\Cli\Constant\CliHeader`** — deleted; superseded by the framework `Header`
- **`App\Cli\Message\AppCliHeader`** — deleted; superseded by the framework `Header`
- **`TestCommand`** — uses `new Header($this->config->namespace, $this->config->version, $route)` directly