### PR TITLE
[Application] Update providers to use instances and align with new framework contracts

### DIFF
--- a/.github/ci/phpunit/composer.json
+++ b/.github/ci/phpunit/composer.json
@@ -3,7 +3,7 @@
     "php" : ">=8.4"
   },
   "require-dev"       : {
-    "valkyrja/phpunit" : "^26.3.0"
+    "valkyrja/phpunit" : "^26.4.0"
   },
   "scripts"           : {
     "check"    : "vendor/bin/phpunit --no-coverage --display-all-issues",

--- a/.github/ci/phpunit/composer.lock
+++ b/.github/ci/phpunit/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "235083ba57b5e0d1f26934f3051eff00",
+    "content-hash": "17f4303cd49dfb7419f0ac37eb537a74",
     "packages": [],
     "packages-dev": [
         {
@@ -3798,16 +3798,16 @@
         },
         {
             "name": "valkyrja/phpunit",
-            "version": "v26.3.0",
+            "version": "v26.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/ci-phpunit-php.git",
-                "reference": "74f18fad2570b4d4833eaac4edb4f9986cc216a4"
+                "reference": "c289798cf0e0f75d02aa57238ce00e2b42f7e405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/ci-phpunit-php/zipball/74f18fad2570b4d4833eaac4edb4f9986cc216a4",
-                "reference": "74f18fad2570b4d4833eaac4edb4f9986cc216a4",
+                "url": "https://api.github.com/repos/valkyrjaio/ci-phpunit-php/zipball/c289798cf0e0f75d02aa57238ce00e2b42f7e405",
+                "reference": "c289798cf0e0f75d02aa57238ce00e2b42f7e405",
                 "shasum": ""
             },
             "require": {
@@ -3816,7 +3816,7 @@
                 "php": ">=8.4",
                 "php-coveralls/php-coveralls": "^2.9.1",
                 "phpunit/phpcov": "^13.0.1",
-                "phpunit/phpunit": "^13.1.7"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "project",
             "autoload": {
@@ -3843,9 +3843,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/ci-phpunit-php/issues",
-                "source": "https://github.com/valkyrjaio/ci-phpunit-php/tree/v26.3.0"
+                "source": "https://github.com/valkyrjaio/ci-phpunit-php/tree/v26.4.0"
             },
-            "time": "2026-04-24T21:52:00+00:00"
+            "time": "2026-05-15T19:38:23+00:00"
         }
     ],
     "aliases": [],

--- a/app/src/App/Cli/App.php
+++ b/app/src/App/Cli/App.php
@@ -26,7 +26,7 @@ final class App extends Cli
     #[Override]
     public static function defaultExceptionHandler(): void
     {
-        ThrowableHandler::enable(
+        (new ThrowableHandler())->enable(
             displayErrors: true
         );
     }

--- a/app/src/App/Cli/App.php
+++ b/app/src/App/Cli/App.php
@@ -26,7 +26,7 @@ final class App extends Cli
     #[Override]
     public static function defaultExceptionHandler(): void
     {
-        (new ThrowableHandler())->enable(
+        new ThrowableHandler()->enable(
             displayErrors: true
         );
     }

--- a/app/src/App/Cli/Command/TestCommand.php
+++ b/app/src/App/Cli/Command/TestCommand.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Cli/Command/TestCommand.php
+++ b/app/src/App/Cli/Command/TestCommand.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -15,7 +15,7 @@ namespace App\Cli\Command;
 
 use App\Cli\Config;
 use App\Cli\Controller\Abstract\Controller;
-use App\Cli\Provider\RouteProvider;
+use App\Cli\Provider\CliRouteProvider;
 use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Cli\Interaction\Message\Answer;
 use Valkyrja\Cli\Interaction\Message\Contract\AnswerContract;
@@ -47,7 +47,7 @@ class TestCommand extends Controller
         description: 'Test command',
         helpText: [self::class, 'help'],
     )]
-    #[RouteHandler([RouteProvider::class, 'testCommandHandler'])]
+    #[RouteHandler([CliRouteProvider::class, 'testCommandHandler'])]
     public function run(RouteContract $route, CliConfigContract $config): OutputContract
     {
         /**

--- a/app/src/App/Cli/Config.example.php
+++ b/app/src/App/Cli/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Cli/Config.example.php
+++ b/app/src/App/Cli/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -17,7 +17,6 @@ namespace App\Cli;
 
 use App\Cli\Provider\ComponentProvider;
 use Valkyrja\Application\Data\CliConfig;
-use Valkyrja\Application\Provider\CliWithHttpApplicationComponentProvider;
 use Valkyrja\Cli\Server\Constant\CommandName;
 
 final class Config extends CliConfig
@@ -37,8 +36,7 @@ final class Config extends CliConfig
             applicationName: 'cli',
             defaultCommandName: CommandName::LIST,
             providers: [
-                CliWithHttpApplicationComponentProvider::class,
-                ComponentProvider::class,
+                new ComponentProvider(),
             ],
             callbacks: [
                 [ComponentProvider::class, 'publish'],

--- a/app/src/App/Cli/Provider/CliRouteProvider.php
+++ b/app/src/App/Cli/Provider/CliRouteProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Cli/Provider/CliRouteProvider.php
+++ b/app/src/App/Cli/Provider/CliRouteProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -21,13 +21,24 @@ use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Provider\Contract\CliRouteProviderContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 
-final class RouteProvider implements CliRouteProviderContract
+final class CliRouteProvider implements CliRouteProviderContract
 {
+    /**
+     * The test command handler.
+     */
+    public static function testCommandHandler(ContainerContract $container, RouteContract $route): OutputContract
+    {
+        return $container->getSingleton(TestCommand::class)->run(
+            $route,
+            $container->getSingleton(CliConfigContract::class),
+        );
+    }
+
     /**
      * @inheritDoc
      */
     #[Override]
-    public static function getControllerClasses(): array
+    public function getControllerClasses(): array
     {
         return [
             TestCommand::class,
@@ -38,19 +49,8 @@ final class RouteProvider implements CliRouteProviderContract
      * @inheritDoc
      */
     #[Override]
-    public static function getRoutes(): array
+    public function getRoutes(): array
     {
         return [];
-    }
-
-    /**
-     * The test command handler.
-     */
-    public static function testCommandHandler(ContainerContract $container, RouteContract $route): OutputContract
-    {
-        return $container->getSingleton(TestCommand::class)->run(
-            $route,
-            $container->getSingleton(CliConfigContract::class),
-        );
     }
 }

--- a/app/src/App/Cli/Provider/ComponentProvider.php
+++ b/app/src/App/Cli/Provider/ComponentProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Cli/Provider/ComponentProvider.php
+++ b/app/src/App/Cli/Provider/ComponentProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -13,64 +13,15 @@ declare(strict_types=1);
 
 namespace App\Cli\Provider;
 
-use App\Http\Provider\ComponentProvider as HttpComponentProvider;
+use App\Http\Provider\HttpRouteProvider;
 use Override;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Application\Provider\CliWithHttpApplicationComponentProvider;
 use Valkyrja\Application\Provider\Contract\ComponentProviderContract;
 use Valkyrja\Container\Provider\ContainerServiceProvider;
 
 final class ComponentProvider implements ComponentProviderContract
 {
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getComponentProviders(ApplicationContract $app): array
-    {
-        return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getContainerProviders(ApplicationContract $app): array
-    {
-        return [
-            DataServiceProvider::class,
-            ServiceProvider::class,
-        ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getEventProviders(ApplicationContract $app): array
-    {
-        return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getCliProviders(ApplicationContract $app): array
-    {
-        return [
-            RouteProvider::class,
-        ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getHttpProviders(ApplicationContract $app): array
-    {
-        return HttpComponentProvider::getHttpProviders($app);
-    }
-
     /**
      * @inheritDoc
      */
@@ -85,5 +36,59 @@ final class ComponentProvider implements ComponentProviderContract
         }
 
         DataServiceProvider::publishContainerData(container: $container);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getComponentProviders(ApplicationContract $app): array
+    {
+        return [
+            new CliWithHttpApplicationComponentProvider(),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getContainerProviders(ApplicationContract $app): array
+    {
+        return [
+            new DataServiceProvider(),
+            new ServiceProvider(),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getEventProviders(ApplicationContract $app): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getCliProviders(ApplicationContract $app): array
+    {
+        return [
+            new CliRouteProvider(),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getHttpProviders(ApplicationContract $app): array
+    {
+        return [
+            new HttpRouteProvider(),
+        ];
     }
 }

--- a/app/src/App/Cli/Provider/DataServiceProvider.php
+++ b/app/src/App/Cli/Provider/DataServiceProvider.php
@@ -31,7 +31,7 @@ final class DataServiceProvider implements ServiceProviderContract
      * @inheritDoc
      */
     #[Override]
-    public static function publishers(): array
+    public function publishers(): array
     {
         return [
             ContainerData::class   => [self::class, 'publishContainerData'],

--- a/app/src/App/Cli/Provider/DataServiceProvider.php
+++ b/app/src/App/Cli/Provider/DataServiceProvider.php
@@ -28,20 +28,6 @@ use Valkyrja\Http\Routing\Data\HttpRoutingData;
 final class DataServiceProvider implements ServiceProviderContract
 {
     /**
-     * @inheritDoc
-     */
-    #[Override]
-    public function publishers(): array
-    {
-        return [
-            ContainerData::class   => [self::class, 'publishContainerData'],
-            EventData::class       => [self::class, 'publishEventData'],
-            CliRoutingData::class  => [self::class, 'publishCliRoutingData'],
-            HttpRoutingData::class => [self::class, 'publishHttpRoutingData'],
-        ];
-    }
-
-    /**
      * Publish the container data.
      */
     public static function publishContainerData(ContainerContract $container): void
@@ -71,5 +57,19 @@ final class DataServiceProvider implements ServiceProviderContract
     public static function publishHttpRoutingData(ContainerContract $container): void
     {
         $container->setSingleton(HttpRoutingData::class, new AppHttpRoutingData());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function publishers(): array
+    {
+        return [
+            ContainerData::class   => [self::class, 'publishContainerData'],
+            EventData::class       => [self::class, 'publishEventData'],
+            CliRoutingData::class  => [self::class, 'publishCliRoutingData'],
+            HttpRoutingData::class => [self::class, 'publishHttpRoutingData'],
+        ];
     }
 }

--- a/app/src/App/Cli/Provider/ServiceProvider.php
+++ b/app/src/App/Cli/Provider/ServiceProvider.php
@@ -23,17 +23,6 @@ use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
 final class ServiceProvider implements ServiceProviderContract
 {
     /**
-     * @inheritDoc
-     */
-    #[Override]
-    public function publishers(): array
-    {
-        return [
-            TestCommand::class => [self::class, 'publishTestCommand'],
-        ];
-    }
-
-    /**
      * Publish the test command.
      */
     public static function publishTestCommand(ContainerContract $container): void
@@ -45,5 +34,16 @@ final class ServiceProvider implements ServiceProviderContract
                 $container->getSingleton(OutputFactoryContract::class),
             )
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function publishers(): array
+    {
+        return [
+            TestCommand::class => [self::class, 'publishTestCommand'],
+        ];
     }
 }

--- a/app/src/App/Cli/Provider/ServiceProvider.php
+++ b/app/src/App/Cli/Provider/ServiceProvider.php
@@ -26,7 +26,7 @@ final class ServiceProvider implements ServiceProviderContract
      * @inheritDoc
      */
     #[Override]
-    public static function publishers(): array
+    public function publishers(): array
     {
         return [
             TestCommand::class => [self::class, 'publishTestCommand'],

--- a/app/src/App/Http/App.php
+++ b/app/src/App/Http/App.php
@@ -26,7 +26,7 @@ final class App extends Http
     #[Override]
     public static function defaultExceptionHandler(): void
     {
-        ThrowableHandler::enable(
+        (new ThrowableHandler())->enable(
             displayErrors: true
         );
     }

--- a/app/src/App/Http/App.php
+++ b/app/src/App/Http/App.php
@@ -26,7 +26,7 @@ final class App extends Http
     #[Override]
     public static function defaultExceptionHandler(): void
     {
-        (new ThrowableHandler())->enable(
+        new ThrowableHandler()->enable(
             displayErrors: true
         );
     }

--- a/app/src/App/Http/Config.example.php
+++ b/app/src/App/Http/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Http/Config.example.php
+++ b/app/src/App/Http/Config.example.php
@@ -5,7 +5,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -17,7 +17,6 @@ namespace App\Http;
 
 use App\Http\Provider\ComponentProvider;
 use Valkyrja\Application\Data\HttpConfig;
-use Valkyrja\Application\Provider\HttpApplicationComponentProvider;
 use Valkyrja\Http\Server\Middleware\CacheResponseMiddleware;
 
 final class Config extends HttpConfig
@@ -35,8 +34,7 @@ final class Config extends HttpConfig
             dataPath: 'src/App/Http/Data',
             dataNamespace: 'App\\Http\\Data',
             providers: [
-                HttpApplicationComponentProvider::class,
-                ComponentProvider::class,
+                new ComponentProvider(),
             ],
             callbacks: [
                 [ComponentProvider::class, 'publish'],

--- a/app/src/App/Http/Controller/HomeController.php
+++ b/app/src/App/Http/Controller/HomeController.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Http/Controller/HomeController.php
+++ b/app/src/App/Http/Controller/HomeController.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace App\Http\Controller;
 
 use App\Http\Controller\Abstract\Controller;
-use App\Http\Provider\RouteProvider;
+use App\Http\Provider\HttpRouteProvider;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Http\Message\Enum\RequestMethod;
 use Valkyrja\Http\Message\Response\Contract\JsonResponseContract;
@@ -41,7 +41,7 @@ class HomeController extends Controller
     #[Route(path: '/version', name: 'version', requestMethods: [RequestMethod::GET])]
     #[Route(path: '/version', name: 'version.post', requestMethods: [RequestMethod::POST])]
     #[Route(path: '/version', name: 'version.put', requestMethods: [RequestMethod::PUT])]
-    #[RouteHandler([RouteProvider::class, 'versionHandler'])]
+    #[RouteHandler([HttpRouteProvider::class, 'versionHandler'])]
     public static function version(ApplicationContract $app, ResponseFactoryContract $responseFactory): TextResponseContract
     {
         return $responseFactory->createTextResponse($app->getVersion());
@@ -51,7 +51,7 @@ class HomeController extends Controller
      * Text action.
      */
     #[Route(path: '/text', name: 'text', requestMethods: [RequestMethod::GET])]
-    #[RouteHandler([RouteProvider::class, 'textHandler'])]
+    #[RouteHandler([HttpRouteProvider::class, 'textHandler'])]
     public static function text(): TextResponseContract
     {
         return new TextResponse('Hello World!');
@@ -62,7 +62,7 @@ class HomeController extends Controller
      * - Example of a view being returned.
      */
     #[Route(path: '/', name: 'welcome')]
-    #[RouteHandler([RouteProvider::class, 'welcomeHandler'])]
+    #[RouteHandler([HttpRouteProvider::class, 'welcomeHandler'])]
     public function welcome(ViewResponseFactoryContract $responseFactory): ResponseContract
     {
         return $responseFactory->createResponseFromView('index/index');
@@ -73,7 +73,7 @@ class HomeController extends Controller
      * - Example of a cacheable view being returned.
      */
     #[Route(path: '/cached', name: 'welcome.cached')]
-    #[RouteHandler([RouteProvider::class, 'welcomeCachedHandler'])]
+    #[RouteHandler([HttpRouteProvider::class, 'welcomeCachedHandler'])]
     #[Middleware(CacheResponseMiddleware::class)]
     public function welcomeCached(ViewResponseFactoryContract $responseFactory): ResponseContract
     {
@@ -85,7 +85,7 @@ class HomeController extends Controller
      * - Example of a view being returned.
      */
     #[Route(path: '/{value}', name: 'dynamicValue')]
-    #[RouteHandler([RouteProvider::class, 'dynamicHandler'])]
+    #[RouteHandler([HttpRouteProvider::class, 'dynamicHandler'])]
     public function dynamic(
         RouteContract $route,
         ViewResponseFactoryContract $responseFactory,
@@ -101,7 +101,7 @@ class HomeController extends Controller
     #[Get]
     #[Head]
     #[Route(path: '/home', name: 'home')]
-    #[RouteHandler([RouteProvider::class, 'homeHandler'])]
+    #[RouteHandler([HttpRouteProvider::class, 'homeHandler'])]
     public function home(ViewResponseFactoryContract $responseFactory): ResponseContract
     {
         return $responseFactory->createResponseFromView('home/home');
@@ -111,7 +111,7 @@ class HomeController extends Controller
      * Json action.
      */
     #[Route(path: '/json', name: 'json')]
-    #[RouteHandler([RouteProvider::class, 'jsonHandler'])]
+    #[RouteHandler([HttpRouteProvider::class, 'jsonHandler'])]
     public function json(ResponseFactoryContract $responseFactory): JsonResponseContract
     {
         return $responseFactory->createJsonResponse(['Json response example']);

--- a/app/src/App/Http/Provider/ComponentProvider.php
+++ b/app/src/App/Http/Provider/ComponentProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Http/Provider/ComponentProvider.php
+++ b/app/src/App/Http/Provider/ComponentProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -16,60 +16,11 @@ namespace App\Http\Provider;
 use Override;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Application\Provider\Contract\ComponentProviderContract;
+use Valkyrja\Application\Provider\HttpApplicationComponentProvider;
 use Valkyrja\Container\Provider\ContainerServiceProvider;
 
 final class ComponentProvider implements ComponentProviderContract
 {
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getComponentProviders(ApplicationContract $app): array
-    {
-        return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getContainerProviders(ApplicationContract $app): array
-    {
-        return [
-            DataServiceProvider::class,
-            ServiceProvider::class,
-        ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getEventProviders(ApplicationContract $app): array
-    {
-        return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getCliProviders(ApplicationContract $app): array
-    {
-        return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getHttpProviders(ApplicationContract $app): array
-    {
-        return [
-            RouteProvider::class,
-        ];
-    }
-
     /**
      * @inheritDoc
      */
@@ -84,5 +35,57 @@ final class ComponentProvider implements ComponentProviderContract
         }
 
         DataServiceProvider::publishContainerData(container: $container);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getComponentProviders(ApplicationContract $app): array
+    {
+        return [
+            new HttpApplicationComponentProvider(),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getContainerProviders(ApplicationContract $app): array
+    {
+        return [
+            new DataServiceProvider(),
+            new ServiceProvider(),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getEventProviders(ApplicationContract $app): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getCliProviders(ApplicationContract $app): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getHttpProviders(ApplicationContract $app): array
+    {
+        return [
+            new HttpRouteProvider(),
+        ];
     }
 }

--- a/app/src/App/Http/Provider/DataServiceProvider.php
+++ b/app/src/App/Http/Provider/DataServiceProvider.php
@@ -26,19 +26,6 @@ use Valkyrja\Http\Routing\Data\HttpRoutingData;
 final class DataServiceProvider implements ServiceProviderContract
 {
     /**
-     * @inheritDoc
-     */
-    #[Override]
-    public function publishers(): array
-    {
-        return [
-            ContainerData::class   => [self::class, 'publishContainerData'],
-            EventData::class       => [self::class, 'publishEventData'],
-            HttpRoutingData::class => [self::class, 'publishHttpRoutingData'],
-        ];
-    }
-
-    /**
      * Publish the container data.
      */
     public static function publishContainerData(ContainerContract $container): void
@@ -60,5 +47,18 @@ final class DataServiceProvider implements ServiceProviderContract
     public static function publishHttpRoutingData(ContainerContract $container): void
     {
         $container->setSingleton(HttpRoutingData::class, new AppHttpRoutingData());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function publishers(): array
+    {
+        return [
+            ContainerData::class   => [self::class, 'publishContainerData'],
+            EventData::class       => [self::class, 'publishEventData'],
+            HttpRoutingData::class => [self::class, 'publishHttpRoutingData'],
+        ];
     }
 }

--- a/app/src/App/Http/Provider/DataServiceProvider.php
+++ b/app/src/App/Http/Provider/DataServiceProvider.php
@@ -29,7 +29,7 @@ final class DataServiceProvider implements ServiceProviderContract
      * @inheritDoc
      */
     #[Override]
-    public static function publishers(): array
+    public function publishers(): array
     {
         return [
             ContainerData::class   => [self::class, 'publishContainerData'],

--- a/app/src/App/Http/Provider/HttpRouteProvider.php
+++ b/app/src/App/Http/Provider/HttpRouteProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Framework package.
+ * This file is part of the Valkyrja Application package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *

--- a/app/src/App/Http/Provider/HttpRouteProvider.php
+++ b/app/src/App/Http/Provider/HttpRouteProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Valkyrja Application package.
+ * This file is part of the Valkyrja Framework package.
  *
  * (c) Melech Mizrachi <melechmizrachi@gmail.com>
  *
@@ -24,28 +24,8 @@ use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Provider\Contract\HttpRouteProviderContract;
 use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 
-final class RouteProvider implements HttpRouteProviderContract
+final class HttpRouteProvider implements HttpRouteProviderContract
 {
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getControllerClasses(): array
-    {
-        return [
-            HomeController::class,
-        ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getRoutes(): array
-    {
-        return [];
-    }
-
     public static function versionHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return HomeController::version(
@@ -100,5 +80,25 @@ final class RouteProvider implements HttpRouteProviderContract
         return $container->getSingleton(HomeController::class)->json(
             $container->getSingleton(ResponseFactoryContract::class),
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getControllerClasses(): array
+    {
+        return [
+            HomeController::class,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getRoutes(): array
+    {
+        return [];
     }
 }

--- a/app/src/App/Http/Provider/ServiceProvider.php
+++ b/app/src/App/Http/Provider/ServiceProvider.php
@@ -26,7 +26,7 @@ final class ServiceProvider implements ServiceProviderContract
      * @inheritDoc
      */
     #[Override]
-    public static function publishers(): array
+    public function publishers(): array
     {
         return [
             HomeController::class => [self::class, 'publishHomeController'],

--- a/app/src/App/Http/Provider/ServiceProvider.php
+++ b/app/src/App/Http/Provider/ServiceProvider.php
@@ -23,17 +23,6 @@ use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
 final class ServiceProvider implements ServiceProviderContract
 {
     /**
-     * @inheritDoc
-     */
-    #[Override]
-    public function publishers(): array
-    {
-        return [
-            HomeController::class => [self::class, 'publishHomeController'],
-        ];
-    }
-
-    /**
      * Publish the home controller.
      */
     public static function publishHomeController(ContainerContract $container): void
@@ -45,5 +34,16 @@ final class ServiceProvider implements ServiceProviderContract
                 $container->getSingleton(ResponseFactoryContract::class)
             )
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function publishers(): array
+    {
+        return [
+            HomeController::class => [self::class, 'publishHomeController'],
+        ];
     }
 }

--- a/app/src/App/Throwable/Handler/ThrowableHandler.php
+++ b/app/src/App/Throwable/Handler/ThrowableHandler.php
@@ -27,7 +27,7 @@ class ThrowableHandler extends WhoopsThrowableHandler
      * @param bool $displayErrors       [optional] Whether to display errors
      */
     #[Override]
-    public static function enable(int $errorReportingLevel = E_ALL, bool $displayErrors = false): void
+    public function enable(int $errorReportingLevel = E_ALL, bool $displayErrors = false): void
     {
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require"           : {
     "php"               : ">=8.4",
     "monolog/monolog"   : "^3.10.0",
-    "valkyrja/valkyrja" : "^26.2.0"
+    "valkyrja/valkyrja" : "^26.3.0"
   },
   "require-dev"       : {
     "filp/whoops"     : "^2.18.4",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev"       : {
     "filp/whoops"     : "^2.18.4",
-    "valkyrja/sindri" : "^26.1.2"
+    "valkyrja/sindri" : "^26.2.0"
   },
   "config"            : {
     "optimize-autoloader" : true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1259b87b7b95de989f643ea0f28a10af",
+    "content-hash": "2e80b36b1defa64bc977d2a5b88d4d4e",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -600,22 +600,22 @@
         },
         {
             "name": "valkyrja/sindri",
-            "version": "v26.1.2",
+            "version": "v26.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/sindri-php.git",
-                "reference": "5057df2789e3c1111c3bb3439fa2792d8190c27f"
+                "reference": "f47332814608c8e8a4752726d5288cd77e656964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/5057df2789e3c1111c3bb3439fa2792d8190c27f",
-                "reference": "5057df2789e3c1111c3bb3439fa2792d8190c27f",
+                "url": "https://api.github.com/repos/valkyrjaio/sindri-php/zipball/f47332814608c8e8a4752726d5288cd77e656964",
+                "reference": "f47332814608c8e8a4752726d5288cd77e656964",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.4",
-                "valkyrja/valkyrja": "^26.1.0"
+                "valkyrja/valkyrja": "^26.3.0"
             },
             "bin": [
                 "bin/sindri"
@@ -645,9 +645,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/sindri-php/issues",
-                "source": "https://github.com/valkyrjaio/sindri-php/tree/v26.1.2"
+                "source": "https://github.com/valkyrjaio/sindri-php/tree/v26.2.0"
             },
-            "time": "2026-05-06T01:30:14+00:00"
+            "time": "2026-05-16T18:07:42+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea79eab8e005cd97d00dbd781faa599d",
+    "content-hash": "1259b87b7b95de989f643ea0f28a10af",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -373,16 +373,16 @@
         },
         {
             "name": "valkyrja/valkyrja",
-            "version": "v26.2.0",
+            "version": "v26.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja-php.git",
-                "reference": "63daf963a2c6672101649efc63e52645f1d5cbe9"
+                "reference": "9ac7d0a83d40de0dacb7c8447b0517264f5a605a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/63daf963a2c6672101649efc63e52645f1d5cbe9",
-                "reference": "63daf963a2c6672101649efc63e52645f1d5cbe9",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/9ac7d0a83d40de0dacb7c8447b0517264f5a605a",
+                "reference": "9ac7d0a83d40de0dacb7c8447b0517264f5a605a",
                 "shasum": ""
             },
             "require": {
@@ -397,11 +397,11 @@
                 "filp/whoops": "<2.18.4",
                 "firebase/php-jwt": "<7.0.5",
                 "guzzlehttp/guzzle": "<7.10.0",
-                "league/flysystem": "<3.33.0",
-                "league/flysystem-aws-s3-v3": "<3.32.0",
+                "league/flysystem": "<3.34.0",
+                "league/flysystem-aws-s3-v3": "<3.34.0",
                 "mailgun/mailgun-php": "<4.5.0",
                 "monolog/monolog": "<3.10.0",
-                "phpmailer/phpmailer": "<7.0.2",
+                "phpmailer/phpmailer": "<7.1.0",
                 "predis/predis": "<3.4.2",
                 "pusher/pusher-php-server": "<7.2.7",
                 "twig/twig": "<3.24.0",
@@ -411,11 +411,11 @@
                 "filp/whoops": "^2.18.4",
                 "firebase/php-jwt": "^7.0.5",
                 "guzzlehttp/guzzle": "^7.10.0",
-                "league/flysystem": "^3.33.0",
-                "league/flysystem-aws-s3-v3": "^3.32.0",
+                "league/flysystem": "^3.34.0",
+                "league/flysystem-aws-s3-v3": "^3.34.0",
                 "mailgun/mailgun-php": "^4.5.0",
                 "monolog/monolog": "^3.10.0",
-                "phpmailer/phpmailer": "^7.0.2",
+                "phpmailer/phpmailer": "^7.1.0",
                 "predis/predis": "^3.4.2",
                 "pusher/pusher-php-server": "^7.2.7",
                 "twig/twig": "^3.24.0",
@@ -429,11 +429,11 @@
                 "filp/whoops": "Required to use the default Throwable handler (^2.18.4)",
                 "firebase/php-jwt": "Required to use the default Jwt adapter (^7.0.5)",
                 "guzzlehttp/guzzle": "Required to use the default Client adapter (^7.10.0).",
-                "league/flysystem": "Required to use the default Filesystem adapter (^3.33.0).",
-                "league/flysystem-aws-s3-v3": "Required to use the s3 Filesystem adapter (^3.32.0)",
+                "league/flysystem": "Required to use the default Filesystem adapter (^3.34.0).",
+                "league/flysystem-aws-s3-v3": "Required to use the s3 Filesystem adapter (^3.34.0)",
                 "mailgun/mailgun-php": "Required to use the Mailgun Mail adapter (^4.5.0).",
                 "monolog/monolog": "Required to use the default Log adapter (^3.10.0).",
-                "phpmailer/phpmailer": "Required to use the default Mail adapter (^7.0.2).",
+                "phpmailer/phpmailer": "Required to use the default Mail adapter (^7.1.0).",
                 "predis/predis": "Required to use the Redis Cache store (^3.4.2).",
                 "pusher/pusher-php-server": "Required to use the Pusher Broadcast adapter (^7.2.7).",
                 "twig/twig": "Required to use the Twig View engine (^3.24.0).",
@@ -463,9 +463,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/valkyrja-php/issues",
-                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/v26.2.0"
+                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/v26.3.0"
             },
-            "time": "2026-05-07T21:44:34+00:00"
+            "time": "2026-05-15T20:30:15+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
# Description

Updates all provider implementations to align with the new Valkyrja framework contracts, which changed `ComponentProviderContract` and `ServiceProviderContract` methods from static to instance. Renames `RouteProvider` to `CliRouteProvider` and `HttpRouteProvider` for clarity. Updates `ThrowableHandler::enable()` and its callers from static to instance. Config `providers` arrays now pass instances instead of class strings.

---

## Types of Changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`App\Cli\App`** / **`App\Http\App`** — call `(new ThrowableHandler())->enable()` instead of static `ThrowableHandler::enable()`
- **`App\Cli\Provider\ComponentProvider`** / **`App\Http\Provider\ComponentProvider`** — converted all provider methods from static to instance; `getComponentProviders()` now returns `new CliWithHttpApplicationComponentProvider()` / `new HttpApplicationComponentProvider()`; `getContainerProviders()` / `getCliProviders()` / `getHttpProviders()` return instances
- **`App\Cli\Provider\DataServiceProvider`** / **`App\Http\Provider\DataServiceProvider`** / **`App\Cli\Provider\ServiceProvider`** / **`App\Http\Provider\ServiceProvider`** — `publishers()` converted from static to instance method
- **`App\Cli\Provider\RouteProvider`** → **`App\Cli\Provider\CliRouteProvider`** — renamed for clarity; converted `getControllerClasses()` and `getRoutes()` from static to instance
- **`App\Http\Provider\RouteProvider`** → **`App\Http\Provider\HttpRouteProvider`** — renamed for clarity; converted `getControllerClasses()` and `getRoutes()` from static to instance
- **`App\Throwable\Handler\ThrowableHandler`** — `enable()` override changed from static to instance method
- **`App\Cli\Config.example.php`** / **`App\Http\Config.example.php`** — `providers` now passes `new ComponentProvider()` instead of class strings; removed redundant `CliWithHttpApplicationComponentProvider` / `HttpApplicationComponentProvider` from config-level providers (now handled by `ComponentProvider::getComponentProviders()`)