### PR TITLE
[Tests] Add full testing for 100% code coverage

### DIFF
--- a/.github/ci/phpcodesniffer/ruleset.xml
+++ b/.github/ci/phpcodesniffer/ruleset.xml
@@ -22,4 +22,6 @@
 
     <exclude-pattern>*/.github/*</exclude-pattern>
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <!-- Generated data files (built by sindri); may use FQNs for colliding class names -->
+    <exclude-pattern>*/app/src/App/*/Data/*</exclude-pattern>
 </ruleset>

--- a/.github/ci/phpunit/phpunit.xml.dist
+++ b/.github/ci/phpunit/phpunit.xml.dist
@@ -37,5 +37,9 @@
         <include>
             <directory>../../../app/src</directory>
         </include>
+        <exclude>
+            <!-- Example/template files are copied by users, never autoloaded -->
+            <directory suffix=".example.php">../../../app/src</directory>
+        </exclude>
     </source>
 </phpunit>

--- a/.github/ci/psalm/psalm.xml
+++ b/.github/ci/psalm/psalm.xml
@@ -15,6 +15,8 @@
 
         <ignoreFiles>
             <directory name="../../../vendor" />
+            <!-- Example/template files are copied by users, never autoloaded -->
+            <file name="../../../app/src/**/*.example.php" />
         </ignoreFiles>
     </projectFiles>
 

--- a/app/src/App/Model/Data.php
+++ b/app/src/App/Model/Data.php
@@ -13,37 +13,15 @@ declare(strict_types=1);
 
 namespace App\Model;
 
-use Valkyrja\Type\Model\Abstract\Model;
-
-class Data extends Model
+class Data
 {
-    /**
-     * @var int
-     */
-    public int $id;
-
     /**
      * @var string
      */
-    protected string $needsExtraLogic;
+    public string $property = 'hello';
 
     /**
-     * Getter for a property with extra logic.
+     * @var string|null
      */
-    protected function getNeedsExtraLogic(): string
-    {
-        // Do extra logic before getting
-
-        return $this->needsExtraLogic;
-    }
-
-    /**
-     * Setter for a property with extra logic.
-     */
-    protected function setNeedsExtraLogic(string $needsExtraLogic): void
-    {
-        // Do extra checks before setting
-
-        $this->needsExtraLogic = $needsExtraLogic;
-    }
+    public string|null $propertyNullable = null;
 }

--- a/app/src/App/Model/SimpleModel.php
+++ b/app/src/App/Model/SimpleModel.php
@@ -13,15 +13,64 @@ declare(strict_types=1);
 
 namespace App\Model;
 
-class SimpleModel
+use Override;
+use Valkyrja\Type\Model\Abstract\Model;
+
+class SimpleModel extends Model
 {
+    /**
+     * @var int
+     */
+    public int $id;
+
     /**
      * @var string
      */
-    public string $property = 'hello';
+    protected string $needsExtraLogic;
 
     /**
-     * @var string|null
+     * Getter for a property with extra logic.
      */
-    public string|null $propertyNullable = null;
+    protected function getNeedsExtraLogic(): string
+    {
+        // Do extra logic before getting
+
+        return $this->needsExtraLogic;
+    }
+
+    /**
+     * Setter for a property with extra logic.
+     */
+    protected function setNeedsExtraLogic(string $needsExtraLogic): void
+    {
+        // Do extra checks before setting
+
+        $this->needsExtraLogic = $needsExtraLogic;
+    }
+
+    /**
+     * Specify which method resolves a property on magic __get.
+     *
+     * @inheritDoc
+     */
+    #[Override]
+    protected function internalGetCallables(): array
+    {
+        return [
+            'needsExtraLogic' => [$this, 'getNeedsExtraLogic'],
+        ];
+    }
+
+    /**
+     * Specify which method resolves a property on magic __set.
+     *
+     * @inheritDoc
+     */
+    #[Override]
+    protected function internalSetCallables(): array
+    {
+        return [
+            'needsExtraLogic' => [$this, 'setNeedsExtraLogic'],
+        ];
+    }
 }

--- a/app/tests/Tests/Unit/Cli/AppTest.php
+++ b/app/tests/Tests/Unit/Cli/AppTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli;
+
+use App\Cli\App;
+use App\Throwable\Handler\ThrowableHandler;
+use PHPUnit\Framework\TestCase;
+
+final class AppTest extends TestCase
+{
+    public function testGetThrowableHandlerReturnsApplicationHandler(): void
+    {
+        self::assertInstanceOf(ThrowableHandler::class, App::getThrowableHandler());
+    }
+
+    public function testDefaultExceptionHandlerRuns(): void
+    {
+        App::defaultExceptionHandler();
+
+        // The application handler's enable() is a no-op, so reaching here is the assertion.
+        self::assertTrue(true);
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Command/TestCommandTest.php
+++ b/app/tests/Tests/Unit/Cli/Command/TestCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Command;
+
+use App\Cli\Command\TestCommand;
+use App\Cli\Config;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
+use Valkyrja\Cli\Interaction\Message\Contract\AnswerContract;
+use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
+use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
+
+final class TestCommandTest extends TestCase
+{
+    private OutputContract $output;
+
+    private TestCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->output = self::createStub(OutputContract::class);
+        $this->output->method('withAddedMessages')->willReturnSelf();
+        $this->output->method('writeMessages')->willReturnSelf();
+
+        $outputFactory = self::createStub(OutputFactoryContract::class);
+        $outputFactory->method('createOutput')->willReturn($this->output);
+
+        $this->command = new TestCommand(self::createStub(InputContract::class), $outputFactory);
+    }
+
+    public function testHelpReturnsMessage(): void
+    {
+        self::assertInstanceOf(MessageContract::class, TestCommand::help());
+    }
+
+    public function testRunReturnsOutput(): void
+    {
+        self::assertInstanceOf(
+            OutputContract::class,
+            $this->command->run(self::createStub(RouteContract::class), new Config()),
+        );
+    }
+
+    public function testAnsweredYes(): void
+    {
+        $answer = self::createStub(AnswerContract::class);
+        $answer->method('getUserResponse')->willReturn('yes');
+
+        self::assertInstanceOf(OutputContract::class, $this->command->answered($this->output, $answer));
+    }
+
+    public function testAnsweredNo(): void
+    {
+        $answer = self::createStub(AnswerContract::class);
+        $answer->method('getUserResponse')->willReturn('no');
+
+        self::assertInstanceOf(OutputContract::class, $this->command->answered($this->output, $answer));
+    }
+}

--- a/app/tests/Tests/Unit/Cli/ConfigTest.php
+++ b/app/tests/Tests/Unit/Cli/ConfigTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli;
+
+use App\Cli\Config;
+use App\Cli\Provider\ComponentProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Application\Data\CliConfig;
+
+final class ConfigTest extends TestCase
+{
+    public function testIsACliConfig(): void
+    {
+        self::assertInstanceOf(CliConfig::class, new Config());
+    }
+
+    public function testConfiguredValues(): void
+    {
+        $config = new Config();
+
+        self::assertSame('App', $config->namespace);
+        self::assertSame('1.0.0', $config->version);
+        self::assertSame('production', $config->environment);
+        self::assertTrue($config->debugMode);
+        self::assertSame('UTC', $config->timezone);
+        self::assertSame('src/App/Cli/Data', $config->dataPath);
+        self::assertSame('App\\Cli\\Data', $config->dataNamespace);
+    }
+
+    public function testRegistersComponentProvider(): void
+    {
+        self::assertInstanceOf(ComponentProvider::class, new Config()->providers[0]);
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Data/AppCliRoutingDataTest.php
+++ b/app/tests/Tests/Unit/Cli/Data/AppCliRoutingDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Data;
+
+use App\Cli\Data\AppCliRoutingData;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Cli\Routing\Data\CliRoutingData;
+
+final class AppCliRoutingDataTest extends TestCase
+{
+    public function testIsACliRoutingData(): void
+    {
+        self::assertInstanceOf(CliRoutingData::class, new AppCliRoutingData());
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Data/AppContainerDataTest.php
+++ b/app/tests/Tests/Unit/Cli/Data/AppContainerDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Data;
+
+use App\Cli\Data\AppContainerData;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Container\Data\ContainerData;
+
+final class AppContainerDataTest extends TestCase
+{
+    public function testIsAContainerData(): void
+    {
+        self::assertInstanceOf(ContainerData::class, new AppContainerData());
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Data/AppEventDataTest.php
+++ b/app/tests/Tests/Unit/Cli/Data/AppEventDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Data;
+
+use App\Cli\Data\AppEventData;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Event\Data\EventData;
+
+final class AppEventDataTest extends TestCase
+{
+    public function testIsAEventData(): void
+    {
+        self::assertInstanceOf(EventData::class, new AppEventData());
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Data/AppHttpRoutingDataTest.php
+++ b/app/tests/Tests/Unit/Cli/Data/AppHttpRoutingDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Data;
+
+use App\Cli\Data\AppHttpRoutingData;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Http\Routing\Data\HttpRoutingData;
+
+final class AppHttpRoutingDataTest extends TestCase
+{
+    public function testIsAHttpRoutingData(): void
+    {
+        self::assertInstanceOf(HttpRoutingData::class, new AppHttpRoutingData());
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Provider/CliRouteProviderTest.php
+++ b/app/tests/Tests/Unit/Cli/Provider/CliRouteProviderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Provider;
+
+use App\Cli\Command\TestCommand;
+use App\Cli\Config;
+use App\Cli\Provider\CliRouteProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
+use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
+use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
+use Valkyrja\Container\Manager\Container;
+
+final class CliRouteProviderTest extends TestCase
+{
+    public function testTestCommandHandler(): void
+    {
+        $output = self::createStub(OutputContract::class);
+        $output->method('withAddedMessages')->willReturnSelf();
+
+        $outputFactory = self::createStub(OutputFactoryContract::class);
+        $outputFactory->method('createOutput')->willReturn($output);
+
+        $container = new Container();
+        $container->setSingleton(CliConfigContract::class, new Config());
+        $container->setSingleton(
+            TestCommand::class,
+            new TestCommand(self::createStub(InputContract::class), $outputFactory)
+        );
+
+        self::assertInstanceOf(
+            OutputContract::class,
+            CliRouteProvider::testCommandHandler($container, self::createStub(RouteContract::class)),
+        );
+    }
+
+    public function testGetControllerClasses(): void
+    {
+        self::assertSame([TestCommand::class], new CliRouteProvider()->getControllerClasses());
+    }
+
+    public function testGetRoutes(): void
+    {
+        self::assertSame([], new CliRouteProvider()->getRoutes());
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Provider/ComponentProviderTest.php
+++ b/app/tests/Tests/Unit/Cli/Provider/ComponentProviderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Provider;
+
+use App\Cli\Provider\CliRouteProvider;
+use App\Cli\Provider\ComponentProvider;
+use App\Cli\Provider\DataServiceProvider;
+use App\Cli\Provider\ServiceProvider;
+use App\Http\Provider\HttpRouteProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Application\Provider\CliWithHttpApplicationComponentProvider;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\Container;
+
+final class ComponentProviderTest extends TestCase
+{
+    public function testPublishInProductionUsesAppContainerData(): void
+    {
+        $container = new Container();
+        $app       = self::createStub(ApplicationContract::class);
+        $app->method('getContainer')->willReturn($container);
+        $app->method('getDebugMode')->willReturn(false);
+
+        ComponentProvider::publish($app);
+
+        self::assertTrue($container->isSingletonInstance(ContainerData::class));
+    }
+
+    public function testPublishInDebugModePublishesContainerData(): void
+    {
+        $container = new Container();
+        $app       = self::createStub(ApplicationContract::class);
+        $app->method('getContainer')->willReturn($container);
+        $app->method('getDebugMode')->willReturn(true);
+        $app->method('getContainerProviders')->willReturn([]);
+        $container->setSingleton(ApplicationContract::class, $app);
+
+        ComponentProvider::publish($app);
+
+        self::assertTrue($container->isSingletonInstance(ContainerData::class));
+    }
+
+    public function testGetComponentProviders(): void
+    {
+        $providers = new ComponentProvider()->getComponentProviders(self::createStub(ApplicationContract::class));
+
+        self::assertCount(1, $providers);
+        self::assertInstanceOf(CliWithHttpApplicationComponentProvider::class, $providers[0]);
+    }
+
+    public function testGetContainerProviders(): void
+    {
+        $providers = new ComponentProvider()->getContainerProviders(self::createStub(ApplicationContract::class));
+
+        self::assertInstanceOf(DataServiceProvider::class, $providers[0]);
+        self::assertInstanceOf(ServiceProvider::class, $providers[1]);
+    }
+
+    public function testGetEventProviders(): void
+    {
+        self::assertSame([], new ComponentProvider()->getEventProviders(self::createStub(ApplicationContract::class)));
+    }
+
+    public function testGetCliProviders(): void
+    {
+        $providers = new ComponentProvider()->getCliProviders(self::createStub(ApplicationContract::class));
+
+        self::assertCount(1, $providers);
+        self::assertInstanceOf(CliRouteProvider::class, $providers[0]);
+    }
+
+    public function testGetHttpProviders(): void
+    {
+        $providers = new ComponentProvider()->getHttpProviders(self::createStub(ApplicationContract::class));
+
+        self::assertCount(1, $providers);
+        self::assertInstanceOf(HttpRouteProvider::class, $providers[0]);
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Provider/DataServiceProviderTest.php
+++ b/app/tests/Tests/Unit/Cli/Provider/DataServiceProviderTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Provider;
+
+use App\Cli\Data\AppCliRoutingData;
+use App\Cli\Data\AppContainerData;
+use App\Cli\Data\AppEventData;
+use App\Cli\Data\AppHttpRoutingData;
+use App\Cli\Provider\DataServiceProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Cli\Routing\Data\CliRoutingData;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Event\Data\EventData;
+use Valkyrja\Http\Routing\Data\HttpRoutingData;
+
+final class DataServiceProviderTest extends TestCase
+{
+    public function testPublishContainerData(): void
+    {
+        $container = new Container();
+
+        DataServiceProvider::publishContainerData($container);
+
+        self::assertInstanceOf(AppContainerData::class, $container->getSingleton(ContainerData::class));
+    }
+
+    public function testPublishEventData(): void
+    {
+        $container = new Container();
+
+        DataServiceProvider::publishEventData($container);
+
+        self::assertInstanceOf(AppEventData::class, $container->getSingleton(EventData::class));
+    }
+
+    public function testPublishCliRoutingData(): void
+    {
+        $container = new Container();
+
+        DataServiceProvider::publishCliRoutingData($container);
+
+        self::assertInstanceOf(AppCliRoutingData::class, $container->getSingleton(CliRoutingData::class));
+    }
+
+    public function testPublishHttpRoutingData(): void
+    {
+        $container = new Container();
+
+        DataServiceProvider::publishHttpRoutingData($container);
+
+        self::assertInstanceOf(AppHttpRoutingData::class, $container->getSingleton(HttpRoutingData::class));
+    }
+
+    public function testPublishers(): void
+    {
+        self::assertSame(
+            [
+                ContainerData::class   => [DataServiceProvider::class, 'publishContainerData'],
+                EventData::class       => [DataServiceProvider::class, 'publishEventData'],
+                CliRoutingData::class  => [DataServiceProvider::class, 'publishCliRoutingData'],
+                HttpRoutingData::class => [DataServiceProvider::class, 'publishHttpRoutingData'],
+            ],
+            new DataServiceProvider()->publishers(),
+        );
+    }
+}

--- a/app/tests/Tests/Unit/Cli/Provider/ServiceProviderTest.php
+++ b/app/tests/Tests/Unit/Cli/Provider/ServiceProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Cli\Provider;
+
+use App\Cli\Command\TestCommand;
+use App\Cli\Provider\ServiceProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Container\Manager\Container;
+
+final class ServiceProviderTest extends TestCase
+{
+    public function testPublishTestCommand(): void
+    {
+        $container = new Container();
+        $container->setSingleton(InputContract::class, self::createStub(InputContract::class));
+        $container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
+
+        ServiceProvider::publishTestCommand($container);
+
+        self::assertInstanceOf(TestCommand::class, $container->getSingleton(TestCommand::class));
+    }
+
+    public function testPublishers(): void
+    {
+        self::assertSame(
+            [
+                TestCommand::class => [ServiceProvider::class, 'publishTestCommand'],
+            ],
+            new ServiceProvider()->publishers(),
+        );
+    }
+}

--- a/app/tests/Tests/Unit/Http/AppTest.php
+++ b/app/tests/Tests/Unit/Http/AppTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http;
+
+use App\Http\App;
+use App\Throwable\Handler\ThrowableHandler;
+use PHPUnit\Framework\TestCase;
+
+final class AppTest extends TestCase
+{
+    public function testGetThrowableHandlerReturnsApplicationHandler(): void
+    {
+        self::assertInstanceOf(ThrowableHandler::class, App::getThrowableHandler());
+    }
+
+    public function testDefaultExceptionHandlerRuns(): void
+    {
+        App::defaultExceptionHandler();
+
+        // The application handler's enable() is a no-op, so reaching here is the assertion.
+        self::assertTrue(true);
+    }
+}

--- a/app/tests/Tests/Unit/Http/ConfigTest.php
+++ b/app/tests/Tests/Unit/Http/ConfigTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http;
+
+use App\Http\Config;
+use App\Http\Provider\ComponentProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Application\Data\HttpConfig;
+
+final class ConfigTest extends TestCase
+{
+    public function testIsAnHttpConfig(): void
+    {
+        self::assertInstanceOf(HttpConfig::class, new Config());
+    }
+
+    public function testConfiguredValues(): void
+    {
+        $config = new Config();
+
+        self::assertSame('App', $config->namespace);
+        self::assertSame('1.0.0', $config->version);
+        self::assertSame('production', $config->environment);
+        self::assertTrue($config->debugMode);
+        self::assertSame('UTC', $config->timezone);
+        self::assertSame('src/App/Http/Data', $config->dataPath);
+        self::assertSame('App\\Http\\Data', $config->dataNamespace);
+    }
+
+    public function testRegistersComponentProvider(): void
+    {
+        self::assertInstanceOf(ComponentProvider::class, new Config()->providers[0]);
+    }
+}

--- a/app/tests/Tests/Unit/Http/Controller/HomeControllerTest.php
+++ b/app/tests/Tests/Unit/Http/Controller/HomeControllerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Controller;
+
+use App\Http\Controller\HomeController;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Response\Contract\JsonResponseContract;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Response\Contract\TextResponseContract;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
+
+final class HomeControllerTest extends TestCase
+{
+    private ResponseFactoryContract $responseFactory;
+
+    private ViewResponseFactoryContract $viewFactory;
+
+    private HomeController $controller;
+
+    protected function setUp(): void
+    {
+        $this->responseFactory = self::createStub(ResponseFactoryContract::class);
+        $this->responseFactory->method('createTextResponse')->willReturn(self::createStub(TextResponseContract::class));
+        $this->responseFactory->method('createJsonResponse')->willReturn(self::createStub(JsonResponseContract::class));
+
+        $this->viewFactory = self::createStub(ViewResponseFactoryContract::class);
+        $this->viewFactory->method('createResponseFromView')->willReturn(self::createStub(ResponseContract::class));
+
+        $this->controller = new HomeController(self::createStub(ServerRequestContract::class), $this->responseFactory);
+    }
+
+    public function testVersionReturnsTextResponse(): void
+    {
+        $app = self::createStub(ApplicationContract::class);
+        $app->method('getVersion')->willReturn('1.0.0');
+
+        self::assertInstanceOf(TextResponseContract::class, HomeController::version($app, $this->responseFactory));
+    }
+
+    public function testTextReturnsTextResponse(): void
+    {
+        self::assertInstanceOf(TextResponseContract::class, HomeController::text());
+    }
+
+    public function testWelcomeReturnsResponse(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, $this->controller->welcome($this->viewFactory));
+    }
+
+    public function testWelcomeCachedReturnsResponse(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, $this->controller->welcomeCached($this->viewFactory));
+    }
+
+    public function testDynamicReturnsResponse(): void
+    {
+        self::assertInstanceOf(
+            ResponseContract::class,
+            $this->controller->dynamic(self::createStub(RouteContract::class), $this->viewFactory, 'abc'),
+        );
+    }
+
+    public function testHomeReturnsResponse(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, $this->controller->home($this->viewFactory));
+    }
+
+    public function testJsonReturnsJsonResponse(): void
+    {
+        self::assertInstanceOf(JsonResponseContract::class, $this->controller->json($this->responseFactory));
+    }
+}

--- a/app/tests/Tests/Unit/Http/Data/AppContainerDataTest.php
+++ b/app/tests/Tests/Unit/Http/Data/AppContainerDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Data;
+
+use App\Http\Data\AppContainerData;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Container\Data\ContainerData;
+
+final class AppContainerDataTest extends TestCase
+{
+    public function testIsAContainerData(): void
+    {
+        self::assertInstanceOf(ContainerData::class, new AppContainerData());
+    }
+}

--- a/app/tests/Tests/Unit/Http/Data/AppEventDataTest.php
+++ b/app/tests/Tests/Unit/Http/Data/AppEventDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Data;
+
+use App\Http\Data\AppEventData;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Event\Data\EventData;
+
+final class AppEventDataTest extends TestCase
+{
+    public function testIsAEventData(): void
+    {
+        self::assertInstanceOf(EventData::class, new AppEventData());
+    }
+}

--- a/app/tests/Tests/Unit/Http/Data/AppHttpRoutingDataTest.php
+++ b/app/tests/Tests/Unit/Http/Data/AppHttpRoutingDataTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Data;
+
+use App\Http\Data\AppHttpRoutingData;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Http\Routing\Data\HttpRoutingData;
+
+final class AppHttpRoutingDataTest extends TestCase
+{
+    public function testIsAHttpRoutingData(): void
+    {
+        self::assertInstanceOf(HttpRoutingData::class, new AppHttpRoutingData());
+    }
+}

--- a/app/tests/Tests/Unit/Http/Provider/ComponentProviderTest.php
+++ b/app/tests/Tests/Unit/Http/Provider/ComponentProviderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Provider;
+
+use App\Http\Provider\ComponentProvider;
+use App\Http\Provider\DataServiceProvider;
+use App\Http\Provider\HttpRouteProvider;
+use App\Http\Provider\ServiceProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Application\Provider\HttpApplicationComponentProvider;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\Container;
+
+final class ComponentProviderTest extends TestCase
+{
+    public function testPublishInProductionUsesAppContainerData(): void
+    {
+        $container = new Container();
+        $app       = self::createStub(ApplicationContract::class);
+        $app->method('getContainer')->willReturn($container);
+        $app->method('getDebugMode')->willReturn(false);
+
+        ComponentProvider::publish($app);
+
+        self::assertTrue($container->isSingletonInstance(ContainerData::class));
+    }
+
+    public function testPublishInDebugModePublishesContainerData(): void
+    {
+        $container = new Container();
+        $app       = self::createStub(ApplicationContract::class);
+        $app->method('getContainer')->willReturn($container);
+        $app->method('getDebugMode')->willReturn(true);
+        $app->method('getContainerProviders')->willReturn([]);
+        $container->setSingleton(ApplicationContract::class, $app);
+
+        ComponentProvider::publish($app);
+
+        self::assertTrue($container->isSingletonInstance(ContainerData::class));
+    }
+
+    public function testGetComponentProviders(): void
+    {
+        $providers = new ComponentProvider()->getComponentProviders(self::createStub(ApplicationContract::class));
+
+        self::assertCount(1, $providers);
+        self::assertInstanceOf(HttpApplicationComponentProvider::class, $providers[0]);
+    }
+
+    public function testGetContainerProviders(): void
+    {
+        $providers = new ComponentProvider()->getContainerProviders(self::createStub(ApplicationContract::class));
+
+        self::assertInstanceOf(DataServiceProvider::class, $providers[0]);
+        self::assertInstanceOf(ServiceProvider::class, $providers[1]);
+    }
+
+    public function testGetEventProviders(): void
+    {
+        self::assertSame([], new ComponentProvider()->getEventProviders(self::createStub(ApplicationContract::class)));
+    }
+
+    public function testGetCliProviders(): void
+    {
+        self::assertSame([], new ComponentProvider()->getCliProviders(self::createStub(ApplicationContract::class)));
+    }
+
+    public function testGetHttpProviders(): void
+    {
+        $providers = new ComponentProvider()->getHttpProviders(self::createStub(ApplicationContract::class));
+
+        self::assertCount(1, $providers);
+        self::assertInstanceOf(HttpRouteProvider::class, $providers[0]);
+    }
+}

--- a/app/tests/Tests/Unit/Http/Provider/DataServiceProviderTest.php
+++ b/app/tests/Tests/Unit/Http/Provider/DataServiceProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Provider;
+
+use App\Http\Data\AppContainerData;
+use App\Http\Data\AppEventData;
+use App\Http\Data\AppHttpRoutingData;
+use App\Http\Provider\DataServiceProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Event\Data\EventData;
+use Valkyrja\Http\Routing\Data\HttpRoutingData;
+
+final class DataServiceProviderTest extends TestCase
+{
+    public function testPublishContainerData(): void
+    {
+        $container = new Container();
+
+        DataServiceProvider::publishContainerData($container);
+
+        self::assertInstanceOf(AppContainerData::class, $container->getSingleton(ContainerData::class));
+    }
+
+    public function testPublishEventData(): void
+    {
+        $container = new Container();
+
+        DataServiceProvider::publishEventData($container);
+
+        self::assertInstanceOf(AppEventData::class, $container->getSingleton(EventData::class));
+    }
+
+    public function testPublishHttpRoutingData(): void
+    {
+        $container = new Container();
+
+        DataServiceProvider::publishHttpRoutingData($container);
+
+        self::assertInstanceOf(AppHttpRoutingData::class, $container->getSingleton(HttpRoutingData::class));
+    }
+
+    public function testPublishers(): void
+    {
+        self::assertSame(
+            [
+                ContainerData::class   => [DataServiceProvider::class, 'publishContainerData'],
+                EventData::class       => [DataServiceProvider::class, 'publishEventData'],
+                HttpRoutingData::class => [DataServiceProvider::class, 'publishHttpRoutingData'],
+            ],
+            new DataServiceProvider()->publishers(),
+        );
+    }
+}

--- a/app/tests/Tests/Unit/Http/Provider/HttpRouteProviderTest.php
+++ b/app/tests/Tests/Unit/Http/Provider/HttpRouteProviderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Provider;
+
+use App\Http\Controller\HomeController;
+use App\Http\Provider\HttpRouteProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Response\Contract\JsonResponseContract;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Response\Contract\TextResponseContract;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\Http\Routing\Data\Contract\DynamicRouteContract;
+use Valkyrja\Http\Routing\Data\Contract\ParameterContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
+
+final class HttpRouteProviderTest extends TestCase
+{
+    private Container $container;
+
+    private RouteContract $route;
+
+    protected function setUp(): void
+    {
+        $responseFactory = self::createStub(ResponseFactoryContract::class);
+        $responseFactory->method('createTextResponse')->willReturn(self::createStub(TextResponseContract::class));
+        $responseFactory->method('createJsonResponse')->willReturn(self::createStub(JsonResponseContract::class));
+
+        $viewFactory = self::createStub(ViewResponseFactoryContract::class);
+        $viewFactory->method('createResponseFromView')->willReturn(self::createStub(ResponseContract::class));
+
+        $app = self::createStub(ApplicationContract::class);
+        $app->method('getVersion')->willReturn('1.0.0');
+
+        $this->container = new Container();
+        $this->container->setSingleton(ApplicationContract::class, $app);
+        $this->container->setSingleton(ResponseFactoryContract::class, $responseFactory);
+        $this->container->setSingleton(ViewResponseFactoryContract::class, $viewFactory);
+        $this->container->setSingleton(
+            HomeController::class,
+            new HomeController(self::createStub(ServerRequestContract::class), $responseFactory)
+        );
+
+        $this->route = self::createStub(RouteContract::class);
+    }
+
+    public function testVersionHandler(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::versionHandler($this->container, $this->route));
+    }
+
+    public function testTextHandler(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::textHandler($this->container, $this->route));
+    }
+
+    public function testWelcomeHandler(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::welcomeHandler($this->container, $this->route));
+    }
+
+    public function testWelcomeCachedHandler(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::welcomeCachedHandler($this->container, $this->route));
+    }
+
+    public function testDynamicHandler(): void
+    {
+        $parameter = self::createStub(ParameterContract::class);
+        $parameter->method('getValue')->willReturn('abc');
+
+        $route = self::createStub(DynamicRouteContract::class);
+        $route->method('getParameter')->willReturn($parameter);
+
+        self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::dynamicHandler($this->container, $route));
+    }
+
+    public function testHomeHandler(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::homeHandler($this->container, $this->route));
+    }
+
+    public function testJsonHandler(): void
+    {
+        self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::jsonHandler($this->container, $this->route));
+    }
+
+    public function testGetControllerClasses(): void
+    {
+        self::assertSame([HomeController::class], new HttpRouteProvider()->getControllerClasses());
+    }
+
+    public function testGetRoutes(): void
+    {
+        self::assertSame([], new HttpRouteProvider()->getRoutes());
+    }
+}

--- a/app/tests/Tests/Unit/Http/Provider/ServiceProviderTest.php
+++ b/app/tests/Tests/Unit/Http/Provider/ServiceProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Provider;
+
+use App\Http\Controller\HomeController;
+use App\Http\Provider\ServiceProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
+
+final class ServiceProviderTest extends TestCase
+{
+    public function testPublishHomeController(): void
+    {
+        $container = new Container();
+        $container->setSingleton(ServerRequestContract::class, self::createStub(ServerRequestContract::class));
+        $container->setSingleton(ResponseFactoryContract::class, self::createStub(ResponseFactoryContract::class));
+
+        ServiceProvider::publishHomeController($container);
+
+        self::assertInstanceOf(HomeController::class, $container->getSingleton(HomeController::class));
+    }
+
+    public function testPublishers(): void
+    {
+        self::assertSame(
+            [
+                HomeController::class => [ServiceProvider::class, 'publishHomeController'],
+            ],
+            new ServiceProvider()->publishers(),
+        );
+    }
+}

--- a/app/tests/Tests/Unit/Model/DataTest.php
+++ b/app/tests/Tests/Unit/Model/DataTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Model;
+
+use App\Model\Data;
+use PHPUnit\Framework\TestCase;
+
+final class DataTest extends TestCase
+{
+    public function testDefaultPropertyValues(): void
+    {
+        $data = new Data();
+
+        self::assertSame('hello', $data->property);
+        self::assertNull($data->propertyNullable);
+    }
+}

--- a/app/tests/Tests/Unit/Model/SimpleModelTest.php
+++ b/app/tests/Tests/Unit/Model/SimpleModelTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Model;
+
+use App\Model\SimpleModel;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Type\Model\Abstract\Model;
+
+final class SimpleModelTest extends TestCase
+{
+    public function testIsAModel(): void
+    {
+        self::assertInstanceOf(Model::class, new SimpleModel());
+    }
+
+    public function testNeedsExtraLogicUsesGetterAndSetterCallables(): void
+    {
+        $model = new SimpleModel();
+
+        // __set routes through internalSetCallables() -> setNeedsExtraLogic().
+        $model->needsExtraLogic = 'value';
+
+        // __get routes through internalGetCallables() -> getNeedsExtraLogic().
+        self::assertSame('value', $model->needsExtraLogic);
+    }
+}

--- a/app/tests/Tests/Unit/Orm/Entity/UserTest.php
+++ b/app/tests/Tests/Unit/Orm/Entity/UserTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Orm\Entity;
+
+use App\Orm\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class UserTest extends TestCase
+{
+    public function testGetTableName(): void
+    {
+        self::assertSame('users', User::getTableName());
+    }
+
+    public function testNeedsExtraLogicUsesGetterAndSetterCallables(): void
+    {
+        $user = new User();
+
+        // __set routes through internalSetCallables() -> setNeedsExtraLogic().
+        $user->needsExtraLogic = 'value';
+
+        // __get routes through internalGetCallables() -> getNeedsExtraLogic().
+        self::assertSame('value', $user->needsExtraLogic);
+    }
+}

--- a/app/tests/Tests/Unit/Throwable/Handler/ThrowableHandlerTest.php
+++ b/app/tests/Tests/Unit/Throwable/Handler/ThrowableHandlerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Throwable\Handler;
+
+use App\Throwable\Handler\ThrowableHandler;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Throwable\Handler\Contract\ThrowableHandlerContract;
+
+final class ThrowableHandlerTest extends TestCase
+{
+    public function testIsAThrowableHandler(): void
+    {
+        self::assertInstanceOf(ThrowableHandlerContract::class, new ThrowableHandler());
+    }
+
+    public function testEnableIsANoOp(): void
+    {
+        new ThrowableHandler()->enable(displayErrors: true);
+
+        self::assertTrue(true);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     }
   },
   "scripts"           : {
-    "post-root-package-install"                   : [
+    "setup-example-files"                         : [
       "php -r \"file_exists('app/src/App/Http/Config.php') || copy('app/src/App/Http/Config.example.php', 'app/src/App/Http/Config.php');\"",
       "php -r \"file_exists('app/src/App/Cli/Config.php') || copy('app/src/App/Cli/Config.example.php', 'app/src/App/Cli/Config.php');\"",
       "php -r \"file_exists('app/src/App/Http/Data/AppContainerData.php') || copy('app/src/App/Http/Data/AppContainerData.example.php', 'app/src/App/Http/Data/AppContainerData.php');\"",
@@ -43,6 +43,15 @@
       "php -r \"file_exists('app/src/App/Cli/Data/AppEventData.php') || copy('app/src/App/Cli/Data/AppEventData.example.php', 'app/src/App/Cli/Data/AppEventData.php');\"",
       "php -r \"file_exists('app/src/App/Cli/Data/AppCliRoutingData.php') || copy('app/src/App/Cli/Data/AppCliRoutingData.example.php', 'app/src/App/Cli/Data/AppCliRoutingData.php');\"",
       "php -r \"file_exists('app/src/App/Cli/Data/AppHttpRoutingData.php') || copy('app/src/App/Cli/Data/AppHttpRoutingData.example.php', 'app/src/App/Cli/Data/AppHttpRoutingData.php');\""
+    ],
+    "post-root-package-install"                   : [
+      "@setup-example-files"
+    ],
+    "post-install-cmd"                            : [
+      "@setup-example-files"
+    ],
+    "post-update-cmd"                             : [
+      "@setup-example-files"
     ],
     "phparkitect"                                 : "cd .github/ci/phparkitect && composer check",
     "phparkitect-outdated-check"                  : "cd .github/ci/phparkitect && composer install && composer outdated --direct --minor-only",


### PR DESCRIPTION
# Description

Brings the `application` skeleton to 100% PHPUnit coverage by adding a complete unit test suite, and fixes a latent bug in the skeleton's example `Model` classes that the tests surfaced.

The skeleton ships as a head-start for new Valkyrja apps, so it should both prove out 100% coverage and demonstrate the correct way to extend a `Model`. While writing the tests, the `Data` / `SimpleModel` example classes were found to be mislabeled and the `Model` subclass was missing the `internalGet/SetCallables` overrides required for its extra-logic property to resolve via magic `__get` / `__set`.

---

## Types of Changes

- [x] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`app/src/App/Model/SimpleModel.php`** — now the real `Model` subclass; added the `id` / `needsExtraLogic` properties, getter/setter, and the missing `#[Override] internalGetCallables()` / `internalSetCallables()` so the extra-logic property resolves correctly (skeleton bug fix)
- **`app/src/App/Model/Data.php`** — now the plain (non-`Model`) example class with simple public properties; swapped naming so `Data` = plain class, `SimpleModel` = `Model` subclass
- **`app/tests/Tests/Unit/**`** — added unit tests across `Cli`, `Http`, `Model`, `Orm`, and `Throwable` (`App`, `Config`, `Controllers`, `Data`, `Providers`, `Entities`, `Handlers`), reaching 100% line/method coverage (74 tests)
- **`.github/ci/phpunit/phpunit.xml.dist`** — excluded `*.example.php` from the coverage `<source>` (templates copied by users, never autoloaded)
- **`.github/ci/psalm/psalm.xml`** — ignored `*.example.php` for the same reason
- **`.github/ci/phpcodesniffer/ruleset.xml`** — excluded the generated `app/src/App/*/Data/*` files (built by Sindri; may use FQNs for colliding class names)
- **`composer.json`** — extracted the example-file copying into a reusable `setup-example-files` script and wired it into `post-root-package-install`, `post-install-cmd`, and `post-update-cmd`