### PR TITLE
[Tests] Add --path-coverage to PHPUnit test coverage

### DIFF
--- a/.github/ci/phpunit/composer.json
+++ b/.github/ci/phpunit/composer.json
@@ -7,7 +7,7 @@
   },
   "scripts"           : {
     "check"    : "vendor/bin/phpunit --no-coverage --display-all-issues",
-    "coverage" : "php -d xdebug.mode=coverage -d memory_limit=-1 vendor/bin/phpunit --coverage-text --stderr"
+    "coverage" : "php -d xdebug.mode=coverage -d memory_limit=-1 vendor/bin/phpunit --path-coverage --coverage-text --stderr"
   },
   "minimum-stability" : "dev",
   "prefer-stable"     : true


### PR DESCRIPTION
# Description

Enables Xdebug path coverage when running the local `coverage` Composer script so branch- and path-level gaps surface alongside line coverage. Path coverage reports every branch, ternary, and logic split — not just executed lines — giving a truer picture of what the test suite actually exercises.

---

## Types of Changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`.github/ci/phpunit/composer.json`** — added `--path-coverage` to the `coverage` script so branch/path coverage is reported together with line coverage