### PR TITLE
[Documentation] Add AGENTS.md agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+**application — example app / skeleton** — Valkyrja **PHP** port.
+
+Before doing any work in this repo, read **both** canonical agent guides:
+
+1. **Cross-language** — https://github.com/valkyrjaio/architecture/blob/master/AGENTS.md
+2. **PHP-specific** — https://github.com/valkyrjaio/architecture/blob/master/php/AGENTS.md
+
+They define the architecture, naming, testing, 100% coverage, CI, and the
+branch/commit/push/PR workflow this repo follows.


### PR DESCRIPTION
# Description

Adds a light `AGENTS.md` to this repository — a pointer directing coding agents to the two canonical guides (cross-language + this language) before doing any work. Part of the org-wide AGENTS.md rollout.

Canonical guides / hub PR: https://github.com/valkyrjaio/architecture/pull/33

## Types of changes

- [x] Documentation improvement

## Changes

- **`AGENTS.md`** — new light stub identifying the repo and linking to the cross-language and language-specific canonical AGENTS.md guides.
