### PR TITLE
[Tests] Add HTTP and CLI entry-point smoke tests

### DIFF
--- a/app/tests/Tests/Functional/Entry/CliEntryTest.php
+++ b/app/tests/Tests/Functional/Entry/CliEntryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Entry;
+
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function exec;
+use function implode;
+
+use const PHP_BINARY;
+
+/**
+ * End-to-end smoke test for the CLI entry point (`app/bin/cli`).
+ *
+ * Runs the real console binary in a subprocess and asserts it boots and lists the
+ * application's own `test` command — catching regressions in the entry wiring,
+ * provider bootstrap, or command routing that class-level tests miss.
+ */
+final class CliEntryTest extends TestCase
+{
+    public function testCliBootsAndListsApplicationCommand(): void
+    {
+        $cli = dirname(__DIR__, 5) . '/app/bin/cli';
+
+        $command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($cli) . ' list 2>&1';
+
+        $output   = [];
+        $exitCode = 0;
+        exec($command, $output, $exitCode);
+
+        $stdout = implode("\n", $output);
+
+        self::assertSame(0, $exitCode, "app/bin/cli did not boot cleanly:\n" . $stdout);
+        // The application's own command is listed.
+        self::assertStringContainsString('test', $stdout);
+        self::assertStringNotContainsString('Fatal error', $stdout);
+        self::assertStringNotContainsString('Uncaught', $stdout);
+    }
+}

--- a/app/tests/Tests/Functional/Entry/HttpEntryTest.php
+++ b/app/tests/Tests/Functional/Entry/HttpEntryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Entry;
+
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function exec;
+use function implode;
+
+use const PHP_BINARY;
+
+/**
+ * End-to-end smoke test for the HTTP entry point (`app/public/index.php`).
+ *
+ * Runs the real front controller in a subprocess and asserts a `GET /` request
+ * boots the application, matches the `welcome` route, and renders its view —
+ * catching regressions in the entry wiring, provider bootstrap, or routing that
+ * class-level tests miss.
+ */
+final class HttpEntryTest extends TestCase
+{
+    public function testIndexHandlesRootRequest(): void
+    {
+        $index = dirname(__DIR__, 5) . '/app/public/index.php';
+
+        $command = 'REQUEST_METHOD=GET REQUEST_URI=/ SCRIPT_NAME=/index.php '
+            . escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($index) . ' 2>&1';
+
+        $output   = [];
+        $exitCode = 0;
+        exec($command, $output, $exitCode);
+
+        $body = implode("\n", $output);
+
+        self::assertSame(0, $exitCode, "index.php did not run cleanly:\n" . $body);
+        // The welcome route rendered the index view (its Valkyrja logo).
+        self::assertStringContainsString('full-logo/orange/php.png', $body);
+        // It was not the not-found view, and it did not fatal.
+        self::assertStringNotContainsString('404', $body);
+        self::assertStringNotContainsString('Fatal error', $body);
+        self::assertStringNotContainsString('Uncaught', $body);
+    }
+}


### PR DESCRIPTION
# Description

Adds end-to-end smoke tests for the application's two entry points so a
regression that breaks the app's actual boot — entry wiring, provider bootstrap,
routing — is caught, even when the class-level unit tests still pass.

- **`HttpEntryTest`** runs the real front controller (`app/public/index.php`) in a
  subprocess for `GET /` and asserts it boots, matches the `welcome` route, and
  renders its view (the index page's Valkyrja logo), with no not-found view and no
  fatal.
- **`CliEntryTest`** runs the real console binary (`app/bin/cli list`) in a
  subprocess and asserts it boots and lists the application's own `test` command,
  with no fatal.

These live in the normal functional suite (not the sindri-phpunit generated-code
build) on purpose: the framework falls back to runtime attribute discovery when
the data cache is empty, so the entry points function against the committed stubs
too. Keeping them here means they run on every PR across the full PHP matrix,
rather than being coupled to the generated-code job.

Verified locally against the stub build: both green;
phpcsfixer / phpcodesniffer / phpstan / psalm / rector / phparkitect all clean.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_

## Changes

- **`app/tests/Tests/Functional/Entry/HttpEntryTest.php`** — subprocess smoke test
  that `app/public/index.php` handles `GET /` and renders the welcome view.
- **`app/tests/Tests/Functional/Entry/CliEntryTest.php`** — subprocess smoke test
  that `app/bin/cli` boots and lists the application's command.

## Related

- Companion generated-code CI check (tests the app against the real sindri output):
  https://github.com/valkyrjaio/valkyrja-starter-app-php/pull/162
- Entry/boot smoke test in the generator itself (`bin/sindri`):
  https://github.com/valkyrjaio/sindri-php/pull/164
