### PR TITLE
[Documentation] Move stable release badge before PHP version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ framework itself, so you can focus on building your application rather than
 cleaning up the foundation.
 
 <p>
-    <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/require/php" alt="PHP Version Require"></a>
     <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/v" alt="Latest Stable Version"></a>
+    <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/require/php" alt="PHP Version Require"></a>
     <a href="https://packagist.org/packages/valkyrja/application"><img src="https://poser.pugx.org/valkyrja/application/license" alt="License"></a>
     <a href="https://github.com/valkyrjaio/valkyrja-starter-app-php/actions/workflows/ci.yml?query=branch%3A26.x"><img src="https://github.com/valkyrjaio/valkyrja-starter-app-php/actions/workflows/ci.yml/badge.svg?branch=26.x" alt="CI Status"></a>
     <a href="https://scrutinizer-ci.com/g/valkyrjaio/valkyrja-starter-app-php/?branch=26.x"><img src="https://scrutinizer-ci.com/g/valkyrjaio/valkyrja-starter-app-php/badges/quality-score.png?b=26.x" alt="Scrutinizer"></a>


### PR DESCRIPTION
# Description

Reorder the README badges so the **Latest Stable Version** badge appears before the **PHP Version Require** badge, matching the badge order already used in the Java and TypeScript repositories. This is purely a reordering of two existing badges — no links or content changes.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [x] Documentation improvement

## Changes

- **`README.md`** — swapped the order of the "Latest Stable Version" and "PHP Version Require" badges so the stable version badge comes first.

## Related PRs

Part of the same cross-repo badge-ordering change:

https://github.com/valkyrjaio/valkyrja-php/pull/918
https://github.com/valkyrjaio/sindri-php/pull/168
https://github.com/valkyrjaio/project-template-php/pull/140