### PR TITLE
[Application] Add HTTP and OpenSwoole runtime end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
     uses: valkyrjaio/ci-phpstan-php/.github/workflows/_workflow-call.yml@2f158990fbf002b8b672653f02efa129f6788299
     with:
       php-version: '8.4'
+      extensions: 'openswoole'
+      composer-options: '--ignore-platform-req=ext-openswoole'
       paths: |
         ci:
           - '.github/ci/phpstan/**'
@@ -182,6 +184,8 @@ jobs:
     with:
       php-version: '8.4'
       run-script: 'psalm-shepherd-with-stats'
+      extensions: 'openswoole'
+      composer-options: '--ignore-platform-req=ext-openswoole'
       paths: |
         ci:
           - '.github/ci/psalm/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     with:
       php-versions: '["8.4", "8.5", "8.6"]'
       php-version-bleeding-edge: '8.6'
-      extensions: 'mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite3, php-pgsql, pdo_sqlite, pdo_pgsql, pdo_mysql xdebug'
+      extensions: 'mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite3, php-pgsql, pdo_sqlite, pdo_pgsql, pdo_mysql, openswoole, xdebug'
       paths: |
         ci:
           - '.github/ci/phpunit/**'

--- a/app/bin/openswoole
+++ b/app/bin/openswoole
@@ -1,0 +1,20 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use App\Http\Config;
+use App\OpenSwoole\App;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+App::run(config: new Config());

--- a/app/src/App/OpenSwoole/App.php
+++ b/app/src/App/OpenSwoole/App.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\OpenSwoole;
+
+use App\Throwable\Handler\ThrowableHandler;
+use OpenSwoole\Http\Server;
+use Override;
+use Valkyrja\Application\Entry\OpenSwoole\OpenSwooleHttp;
+use Valkyrja\Throwable\Handler\Contract\ThrowableHandlerContract;
+
+use function getenv;
+
+final class App extends OpenSwooleHttp
+{
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public static function defaultExceptionHandler(): void
+    {
+        new ThrowableHandler()->enable(
+            displayErrors: true
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public static function getThrowableHandler(): ThrowableHandlerContract
+    {
+        return new ThrowableHandler();
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Host and port are read from the environment so the server can be bound to
+     * a chosen address (e.g. a free port during end-to-end tests).
+     */
+    #[Override]
+    public static function getSwooleServer(): Server
+    {
+        $host = getenv('APP_OPENSWOOLE_HOST');
+        $port = getenv('APP_OPENSWOOLE_PORT');
+
+        return new Server(
+            $host !== false ? $host : '127.0.0.1',
+            $port !== false ? (int) $port : 9501
+        );
+    }
+}

--- a/app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php
+++ b/app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Abstract;
+
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function dirname;
+use function explode;
+use function fclose;
+use function file_get_contents;
+use function fsockopen;
+use function getenv;
+use function is_resource;
+use function microtime;
+use function proc_close;
+use function proc_get_status;
+use function proc_open;
+use function proc_terminate;
+use function stream_context_create;
+use function stream_get_contents;
+use function stream_set_blocking;
+use function stream_socket_get_name;
+use function stream_socket_server;
+use function usleep;
+
+/**
+ * Base case for runtime end-to-end tests.
+ *
+ * Boots the real application under a given HTTP runtime in a subprocess, waits
+ * for it to accept connections, exposes a simple GET helper, and always tears
+ * the process down — so subclasses assert on the response an actual HTTP request
+ * produces, exercising the entry wiring end to end.
+ */
+abstract class RuntimeServerTestCase extends TestCase
+{
+    protected int $port = 0;
+
+    /** @var resource|null */
+    private $process;
+
+    /** @var array<int, resource> */
+    private array $pipes = [];
+
+    protected function tearDown(): void
+    {
+        $this->stopServer();
+    }
+
+    /**
+     * Get the application root directory (the repository root).
+     */
+    protected function appRoot(): string
+    {
+        return dirname(__DIR__, 5);
+    }
+
+    /**
+     * Reserve a free localhost TCP port.
+     */
+    protected function findFreePort(): int
+    {
+        $server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+
+        self::assertIsResource($server, "Unable to reserve a free port: $errstr ($errno)");
+
+        $name = stream_socket_get_name($server, false);
+
+        fclose($server);
+
+        self::assertNotFalse($name, 'Unable to resolve the reserved port name.');
+
+        return (int) explode(':', $name)[1];
+    }
+
+    /**
+     * Start a server process from the given command and wait for it to listen.
+     *
+     * @param list<string>          $command The command and its arguments
+     * @param array<string, string> $env     Extra environment variables
+     */
+    protected function startServer(array $command, array $env = []): void
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open(
+            $command,
+            $descriptors,
+            $this->pipes,
+            $this->appRoot(),
+            $env === [] ? null : [...getenv(), ...$env]
+        );
+
+        self::assertIsResource($process, 'Unable to start the server process.');
+
+        $this->process = $process;
+
+        foreach ([1, 2] as $fd) {
+            stream_set_blocking($this->pipes[$fd], false);
+        }
+
+        $this->waitForPort();
+    }
+
+    /**
+     * Wait for the reserved port to accept a connection.
+     */
+    protected function waitForPort(float $timeoutSeconds = 10.0): void
+    {
+        $deadline = microtime(true) + $timeoutSeconds;
+
+        while (microtime(true) < $deadline) {
+            $connection = @fsockopen('127.0.0.1', $this->port, $errno, $errstr, 0.2);
+
+            if (is_resource($connection)) {
+                fclose($connection);
+
+                return;
+            }
+
+            if (! $this->isProcessRunning()) {
+                self::fail("Server process exited before listening:\n" . $this->drainOutput());
+            }
+
+            usleep(100_000);
+        }
+
+        self::fail("Server did not start listening on port {$this->port} in time:\n" . $this->drainOutput());
+    }
+
+    /**
+     * Perform a GET request against the running server.
+     */
+    protected function httpGet(string $path): string
+    {
+        $context = stream_context_create([
+            'http' => [
+                'ignore_errors' => true,
+                'timeout'       => 5,
+            ],
+        ]);
+
+        $body = @file_get_contents("http://127.0.0.1:{$this->port}{$path}", false, $context);
+
+        if ($body === false) {
+            self::fail("Request to $path failed:\n" . $this->drainOutput());
+        }
+
+        return $body;
+    }
+
+    /**
+     * Determine whether the server process is still running.
+     */
+    private function isProcessRunning(): bool
+    {
+        if (! is_resource($this->process)) {
+            return false;
+        }
+
+        $status = proc_get_status($this->process);
+
+        return $status['running'] ?? false;
+    }
+
+    /**
+     * Read whatever the process has written to stdout and stderr so far.
+     */
+    private function drainOutput(): string
+    {
+        $output = '';
+
+        foreach ($this->pipes as $pipe) {
+            if (is_resource($pipe)) {
+                $output .= (string) @stream_get_contents($pipe);
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Terminate the server process and close its pipes.
+     */
+    private function stopServer(): void
+    {
+        if (is_resource($this->process)) {
+            proc_terminate($this->process);
+            proc_close($this->process);
+
+            $this->process = null;
+        }
+
+        $this->pipes = array_map(
+            static function ($pipe): void {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            },
+            $this->pipes
+        );
+
+        $this->pipes = [];
+    }
+}

--- a/app/tests/Tests/Functional/Entry/HttpServerEntryTest.php
+++ b/app/tests/Tests/Functional/Entry/HttpServerEntryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Entry;
+
+use App\Tests\Functional\Abstract\RuntimeServerTestCase;
+
+use const PHP_BINARY;
+
+/**
+ * End-to-end test for the standard HTTP runtime.
+ *
+ * Serves `app/public` through PHP's built-in web server and asserts a real
+ * `GET /` HTTP request boots the application, matches the welcome route, and
+ * renders its view — exercising the full front-controller path over a socket.
+ */
+final class HttpServerEntryTest extends RuntimeServerTestCase
+{
+    public function testServesRootRequestOverHttp(): void
+    {
+        $this->port = $this->findFreePort();
+
+        $this->startServer([
+            PHP_BINARY,
+            '-S',
+            "127.0.0.1:{$this->port}",
+            '-t',
+            'app/public',
+        ]);
+
+        $body = $this->httpGet('/');
+
+        // The welcome route rendered the index view (its Valkyrja logo).
+        self::assertStringContainsString('full-logo/orange/php.png', $body);
+        self::assertStringNotContainsString('404', $body);
+        self::assertStringNotContainsString('Fatal error', $body);
+        self::assertStringNotContainsString('Uncaught', $body);
+    }
+}

--- a/app/tests/Tests/Functional/Entry/OpenSwooleEntryTest.php
+++ b/app/tests/Tests/Functional/Entry/OpenSwooleEntryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Entry;
+
+use App\Tests\Functional\Abstract\RuntimeServerTestCase;
+use Valkyrja\Application\Entry\OpenSwoole\OpenSwooleHttp;
+
+use function extension_loaded;
+use function method_exists;
+
+use const PHP_BINARY;
+
+/**
+ * End-to-end test for the OpenSwoole runtime.
+ *
+ * Boots `app/bin/openswoole` as a real OpenSwoole HTTP server and asserts a live
+ * `GET /` request boots the application, matches the welcome route, and renders
+ * its view — exercising the OpenSwoole request/response bridge end to end.
+ *
+ * Skipped when the openswoole extension is unavailable or the installed
+ * framework predates the request/response bridge (so it never fails against an
+ * older release that cannot serve a live OpenSwoole request).
+ */
+final class OpenSwooleEntryTest extends RuntimeServerTestCase
+{
+    protected function setUp(): void
+    {
+        if (! extension_loaded('openswoole')) {
+            self::markTestSkipped('The openswoole extension is not loaded.');
+        }
+
+        if (! method_exists(OpenSwooleHttp::class, 'handleSwooleRequest')) {
+            self::markTestSkipped('The installed framework predates the OpenSwoole request/response bridge.');
+        }
+    }
+
+    public function testServesRootRequestOverHttp(): void
+    {
+        $this->port = $this->findFreePort();
+
+        $this->startServer(
+            [PHP_BINARY, 'app/bin/openswoole'],
+            [
+                'APP_OPENSWOOLE_HOST' => '127.0.0.1',
+                'APP_OPENSWOOLE_PORT' => (string) $this->port,
+            ]
+        );
+
+        $body = $this->httpGet('/');
+
+        // The welcome route rendered the index view (its Valkyrja logo).
+        self::assertStringContainsString('full-logo/orange/php.png', $body);
+        self::assertStringNotContainsString('404', $body);
+        self::assertStringNotContainsString('Fatal error', $body);
+        self::assertStringNotContainsString('Uncaught', $body);
+    }
+}

--- a/app/tests/Tests/Unit/OpenSwoole/AppTest.php
+++ b/app/tests/Tests/Unit/OpenSwoole/AppTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\OpenSwoole;
+
+use App\OpenSwoole\App;
+use App\Throwable\Handler\ThrowableHandler;
+use OpenSwoole\Http\Server;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+use function extension_loaded;
+use function putenv;
+
+/**
+ * OpenSwoole permits a single server per process, so each test runs in an
+ * isolated process.
+ */
+#[RunTestsInSeparateProcesses]
+final class AppTest extends TestCase
+{
+    public function testGetThrowableHandlerReturnsApplicationHandler(): void
+    {
+        self::assertInstanceOf(ThrowableHandler::class, App::getThrowableHandler());
+    }
+
+    public function testDefaultExceptionHandlerRuns(): void
+    {
+        App::defaultExceptionHandler();
+
+        // The application handler's enable() is a no-op, so reaching here is the assertion.
+        self::assertTrue(true);
+    }
+
+    public function testGetSwooleServerUsesEnvironmentHostAndPort(): void
+    {
+        if (! extension_loaded('openswoole')) {
+            self::markTestSkipped('The openswoole extension is not loaded.');
+        }
+
+        putenv('APP_OPENSWOOLE_HOST=127.0.0.1');
+        putenv('APP_OPENSWOOLE_PORT=12345');
+
+        try {
+            self::assertInstanceOf(Server::class, App::getSwooleServer());
+        } finally {
+            putenv('APP_OPENSWOOLE_HOST');
+            putenv('APP_OPENSWOOLE_PORT');
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require"           : {
     "php"               : ">=8.4",
     "monolog/monolog"   : "^3.10.0",
-    "valkyrja/valkyrja" : "^26.5.1"
+    "valkyrja/valkyrja" : "^26.5.2"
   },
   "require-dev"       : {
     "filp/whoops"     : "^2.18.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8bec300d7a7a9c7e7e17e4bd1054685",
+    "content-hash": "156ddb46baf8888f3ab6ca54abd46d8f",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -373,16 +373,16 @@
         },
         {
             "name": "valkyrja/valkyrja",
-            "version": "v26.5.1",
+            "version": "v26.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/valkyrjaio/valkyrja-php.git",
-                "reference": "161cd8cc7e693dc1add0bbac5a2d7f0c5cd4fae5"
+                "reference": "92597163e0a517e294b3cce4c9e1aae96cfab8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/161cd8cc7e693dc1add0bbac5a2d7f0c5cd4fae5",
-                "reference": "161cd8cc7e693dc1add0bbac5a2d7f0c5cd4fae5",
+                "url": "https://api.github.com/repos/valkyrjaio/valkyrja-php/zipball/92597163e0a517e294b3cce4c9e1aae96cfab8a1",
+                "reference": "92597163e0a517e294b3cce4c9e1aae96cfab8a1",
                 "shasum": ""
             },
             "require": {
@@ -466,9 +466,9 @@
             ],
             "support": {
                 "issues": "https://github.com/valkyrjaio/valkyrja-php/issues",
-                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/v26.5.1"
+                "source": "https://github.com/valkyrjaio/valkyrja-php/tree/v26.5.2"
             },
-            "time": "2026-07-26T02:00:11+00:00"
+            "time": "2026-07-26T23:08:09+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
# Description

Adds real, over-the-socket end-to-end tests for the starter app's HTTP runtimes,
booting the actual application in a subprocess server and asserting a live
`GET /` renders the welcome view. This complements the existing CGI-style
`HttpEntryTest`/`CliEntryTest` with true "start the server and hit it" coverage
and introduces a shared harness the remaining worker runtimes will reuse.

This first PR covers the two runtimes that can be exercised here: the **standard
HTTP** runtime (PHP's built-in server over `app/public`) and the **OpenSwoole**
runtime (a real OpenSwoole HTTP server via a new `app/bin/openswoole`, exercising
the framework's OpenSwoole request/response bridge). Follow-up PRs will add the
RoadRunner and FrankenPHP runtimes, each with the CI job needed to run their
server.

To let the OpenSwoole e2e run — and because the OpenSwoole bridge only serves
correctly as of `valkyrja/valkyrja` v26.5.2 — the dependency is bumped to
`^26.5.2` and the PHPUnit CI job now loads the `openswoole` extension. The
OpenSwoole test self-skips when the extension is absent or the installed
framework predates the bridge, so it never fails against an older environment.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php`** — shared harness: reserves a free port, starts a server subprocess, waits for it to listen, performs a GET, and always tears the process down.
- **`app/tests/Tests/Functional/Entry/HttpServerEntryTest.php`** — serves `app/public` via PHP's built-in server and asserts a live `GET /` renders the welcome view.
- **`app/src/App/OpenSwoole/App.php`** — OpenSwoole entry for the app (throwable-handler overrides mirroring `App\Http\App`; host/port read from the environment for testability).
- **`app/bin/openswoole`** — console entry that boots the app under an OpenSwoole HTTP server.
- **`app/tests/Tests/Functional/Entry/OpenSwooleEntryTest.php`** — boots `app/bin/openswoole` and asserts a live `GET /` renders the welcome view; skips when the extension/bridge is unavailable.
- **`composer.json` / `composer.lock`** — require `valkyrja/valkyrja` `^26.5.2` (first release whose OpenSwoole bridge serves live requests).
- **`.github/workflows/ci.yml`** — load the `openswoole` extension in the PHPUnit job so the OpenSwoole e2e runs in CI.
