### PR TITLE
[Application] Add FrankenPHP runtime end-to-end test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,64 @@ jobs:
           RR_BINARY: ${{ github.workspace }}/rr
         run: .github/ci/phpunit/vendor/bin/phpunit -c .github/ci/phpunit/phpunit.xml.dist --filter RoadRunnerEntryTest
 
+  # Dedicated end-to-end job for the FrankenPHP runtime. It downloads the real
+  # FrankenPHP server binary and runs the app under its worker mode, which the
+  # shared PHPUnit workflow cannot do (no hook to fetch a server binary).
+  # FrankenPhpEntryTest self-skips unless FRANKENPHP_BINARY is set.
+  frankenphp-e2e:
+    name: FrankenPHP E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Determine if workflow should run based on files changed
+        id: changes
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          filters: |
+            files:
+              - '.github/ci/phpunit/**'
+              - '.github/workflows/ci.yml'
+              - 'app/bin/franken-worker.php'
+              - 'app/src/**/*.php'
+              - 'app/tests/**/*.php'
+              - 'composer.json'
+
+      - name: Setup PHP
+        if: steps.changes.outputs.files == 'true'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.4'
+          extensions: 'mbstring, intl, sodium, fileinfo, pdo, php-sqlite3, pdo_sqlite'
+
+      - name: Install root Composer dependencies
+        if: steps.changes.outputs.files == 'true'
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3.2.1
+        with:
+          composer-options: --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Download the FrankenPHP server binary
+        if: steps.changes.outputs.files == 'true'
+        run: |
+          curl -fsSL --proto '=https' --proto-redir '=https' --tlsv1.2 -o frankenphp https://github.com/dunglas/frankenphp/releases/latest/download/frankenphp-linux-x86_64
+          chmod +x frankenphp
+
+      - name: Install PHPUnit Composer dependencies
+        if: steps.changes.outputs.files == 'true'
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3.2.1
+        with:
+          composer-options: --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/phpunit
+
+      - name: Run the FrankenPHP end-to-end test
+        if: steps.changes.outputs.files == 'true'
+        env:
+          FRANKENPHP_BINARY: ${{ github.workspace }}/frankenphp
+        run: .github/ci/phpunit/vendor/bin/phpunit -c .github/ci/phpunit/phpunit.xml.dist --filter FrankenPhpEntryTest
+
   psalm:
     name: Psalm
     uses: valkyrjaio/ci-psalm-php/.github/workflows/_workflow-call.yml@1f216925b5ff78a88c1728d734cab165071b11c2

--- a/app/bin/franken-worker.php
+++ b/app/bin/franken-worker.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use App\FrankenPhp\App;
+use App\Http\Config;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+App::run(config: new Config());

--- a/app/src/App/FrankenPhp/App.php
+++ b/app/src/App/FrankenPhp/App.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\FrankenPhp;
+
+use App\Throwable\Handler\ThrowableHandler;
+use Override;
+use Valkyrja\Application\Entry\FrankenPhp\FrankenPhpHttp;
+use Valkyrja\Throwable\Handler\Contract\ThrowableHandlerContract;
+
+final class App extends FrankenPhpHttp
+{
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public static function defaultExceptionHandler(): void
+    {
+        new ThrowableHandler()->enable(
+            displayErrors: true
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public static function getThrowableHandler(): ThrowableHandlerContract
+    {
+        return new ThrowableHandler();
+    }
+}

--- a/app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php
+++ b/app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php
@@ -15,7 +15,6 @@ namespace App\Tests\Functional\Abstract;
 
 use PHPUnit\Framework\TestCase;
 
-use function array_map;
 use function dirname;
 use function explode;
 use function fclose;
@@ -196,25 +195,48 @@ abstract class RuntimeServerTestCase extends TestCase
 
     /**
      * Terminate the server process and close its pipes.
+     *
+     * Sends SIGTERM, waits briefly for a graceful exit, then forces SIGKILL so a
+     * runtime with a long shutdown grace period (e.g. FrankenPHP) cannot hang the
+     * teardown.
      */
     private function stopServer(): void
     {
-        if (is_resource($this->process)) {
-            proc_terminate($this->process);
-            proc_close($this->process);
+        if (! is_resource($this->process)) {
+            $this->pipes = [];
 
-            $this->process = null;
+            return;
         }
 
-        $this->pipes = array_map(
-            static function ($pipe): void {
-                if (is_resource($pipe)) {
-                    fclose($pipe);
-                }
-            },
-            $this->pipes
-        );
+        proc_terminate($this->process);
 
-        $this->pipes = [];
+        $deadline = microtime(true) + 3.0;
+
+        while (microtime(true) < $deadline) {
+            $status = proc_get_status($this->process);
+
+            if (! ($status['running'] ?? false)) {
+                break;
+            }
+
+            usleep(50_000);
+        }
+
+        $status = proc_get_status($this->process);
+
+        if ($status['running'] ?? false) {
+            proc_terminate($this->process, 9);
+        }
+
+        foreach ($this->pipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+
+        proc_close($this->process);
+
+        $this->process = null;
+        $this->pipes   = [];
     }
 }

--- a/app/tests/Tests/Functional/Entry/FrankenPhpEntryTest.php
+++ b/app/tests/Tests/Functional/Entry/FrankenPhpEntryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Entry;
+
+use App\Tests\Functional\Abstract\RuntimeServerTestCase;
+
+use function getenv;
+use function is_string;
+
+/**
+ * End-to-end test for the FrankenPHP runtime.
+ *
+ * Runs the real FrankenPHP worker server, which boots
+ * `app/bin/franken-worker.php`, and asserts a live `GET /` request boots the
+ * application, matches the welcome route, and renders its view — exercising the
+ * FrankenPHP worker entry end to end.
+ *
+ * The FrankenPHP binary is provided explicitly via the FRANKENPHP_BINARY
+ * environment variable (the dedicated CI job installs it and sets it). The test
+ * skips when it is unset, so it never fails against an environment that lacks the
+ * runtime.
+ */
+final class FrankenPhpEntryTest extends RuntimeServerTestCase
+{
+    private string $binary = 'frankenphp';
+
+    protected function setUp(): void
+    {
+        $binary = getenv('FRANKENPHP_BINARY');
+
+        if (! is_string($binary) || $binary === '') {
+            self::markTestSkipped('Set FRANKENPHP_BINARY to the frankenphp binary to run this test.');
+        }
+
+        $this->binary = $binary;
+    }
+
+    public function testServesRootRequestOverHttp(): void
+    {
+        $this->port = $this->findFreePort();
+
+        $worker = $this->appRoot() . '/app/bin/franken-worker.php';
+
+        $this->startServer([
+            $this->binary,
+            'php-server',
+            '--listen',
+            "127.0.0.1:{$this->port}",
+            '--root',
+            'app/public',
+            '--worker',
+            $worker,
+        ]);
+
+        $body = $this->httpGet('/');
+
+        // The welcome route rendered the index view (its Valkyrja logo).
+        self::assertStringContainsString('full-logo/orange/php.png', $body);
+        self::assertStringNotContainsString('404', $body);
+        self::assertStringNotContainsString('Fatal error', $body);
+        self::assertStringNotContainsString('Uncaught', $body);
+    }
+}

--- a/app/tests/Tests/Unit/FrankenPhp/AppTest.php
+++ b/app/tests/Tests/Unit/FrankenPhp/AppTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\FrankenPhp;
+
+use App\FrankenPhp\App;
+use App\Throwable\Handler\ThrowableHandler;
+use PHPUnit\Framework\TestCase;
+
+final class AppTest extends TestCase
+{
+    public function testGetThrowableHandlerReturnsApplicationHandler(): void
+    {
+        self::assertInstanceOf(ThrowableHandler::class, App::getThrowableHandler());
+    }
+
+    public function testDefaultExceptionHandlerRuns(): void
+    {
+        App::defaultExceptionHandler();
+
+        // The application handler's enable() is a no-op, so reaching here is the assertion.
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
# Description

Adds the **FrankenPHP** runtime to the starter app with a real end-to-end test —
the third per-runtime follow-up to #168 (HTTP + OpenSwoole). The app can now be
served under FrankenPHP's worker mode (`app/bin/franken-worker.php`), and
`FrankenPhpEntryTest` runs the real `frankenphp php-server --worker` and asserts
a live `GET /` renders the welcome view — exercising the FrankenPHP worker entry
end to end. Verified locally against FrankenPHP v1.12.6.

Because the shared PHPUnit workflow has no hook to fetch a server binary, a
dedicated `FrankenPHP E2E` CI job downloads the FrankenPHP binary and runs the
test with `FRANKENPHP_BINARY` set. The test self-skips when `FRANKENPHP_BINARY`
is unset, so it never fails against an environment that lacks the runtime.

This PR also hardens the shared runtime server harness: teardown now sends
SIGTERM, waits briefly, then forces SIGKILL, so a runtime with a long shutdown
grace period (FrankenPHP's) cannot hang the test run. `App\FrankenPhp\App` is
covered by a unit test (the e2e runs it in a subprocess, which coverage cannot
measure). All GitHub Actions in the workflow are pinned to commit SHAs.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`app/src/App/FrankenPhp/App.php`** — FrankenPHP entry for the app (throwable-handler overrides mirroring `App\Http\App`).
- **`app/bin/franken-worker.php`** — the FrankenPHP worker script that boots the app.
- **`app/tests/Tests/Functional/Entry/FrankenPhpEntryTest.php`** — runs the real FrankenPHP worker server and asserts a live `GET /` renders the welcome view; skips unless `FRANKENPHP_BINARY` is set.
- **`app/tests/Tests/Unit/FrankenPhp/AppTest.php`** — covers the FrankenPHP entry class in-process.
- **`app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php`** — teardown now force-kills (SIGKILL) after a short grace period so a slow-shutting-down server cannot hang the run.
- **`.github/workflows/ci.yml`** — add a `FrankenPHP E2E` job that downloads the binary and runs the test; pin all GitHub Actions to commit SHAs.
