### PR TITLE
[Http] Add a route for every routing permutation with regression, smoke, and end-to-end tests

### DIFF
--- a/.github/ci/sindri-phpunit/tests/Cli/Data/AppHttpRoutingDataTest.php
+++ b/.github/ci/sindri-phpunit/tests/Cli/Data/AppHttpRoutingDataTest.php
@@ -32,9 +32,11 @@ final class AppHttpRoutingDataTest extends TestCase
 
         self::assertInstanceOf(HttpRoutingData::class, $data);
 
-        self::assertCount(9, $data->routes);
+        // Nine routes on HomeController plus the eighteen routing permutations.
+        self::assertCount(27, $data->routes);
         self::assertArrayHasKey('welcome', $data->routes);
         self::assertArrayHasKey('version', $data->routes);
+        self::assertArrayHasKey('permutations.num', $data->routes);
 
         foreach ($data->routes as $routeFactory) {
             self::assertInstanceOf(RouteContract::class, $routeFactory());

--- a/.github/ci/sindri-phpunit/tests/Http/Data/AppHttpRoutingDataTest.php
+++ b/.github/ci/sindri-phpunit/tests/Http/Data/AppHttpRoutingDataTest.php
@@ -34,8 +34,8 @@ final class AppHttpRoutingDataTest extends TestCase
 
         self::assertInstanceOf(HttpRoutingData::class, $data);
 
-        // The application defines nine HTTP routes across its controllers/providers.
-        self::assertCount(9, $data->routes);
+        // Nine routes on HomeController plus the eighteen routing permutations.
+        self::assertCount(27, $data->routes);
         self::assertArrayHasKey('welcome', $data->routes);
         self::assertArrayHasKey('welcome.cached', $data->routes);
         self::assertArrayHasKey('version', $data->routes);
@@ -57,5 +57,50 @@ final class AppHttpRoutingDataTest extends TestCase
         self::assertArrayHasKey('GET', $data->dynamicPaths);
         self::assertArrayHasKey('HEAD', $data->dynamicPaths);
         self::assertNotEmpty($data->regexes);
+    }
+
+    /**
+     * Every routing permutation is generated with the exact regex the framework's
+     * processor produces, so the cached routing table matches runtime matching.
+     */
+    public function testGeneratesExpectedRegexForEveryPermutation(): void
+    {
+        $data = new AppHttpRoutingData();
+
+        $expected = [
+            'permutations.num'                => '/^\/permutations\/num\/(?<value>\d+)$/',
+            'permutations.id'                 => '/^\/permutations\/id\/(?<value>\d+)$/',
+            'permutations.slug'               => '/^\/permutations\/slug\/(?<value>[a-zA-Z0-9-]+)$/',
+            'permutations.alpha'              => '/^\/permutations\/alpha\/(?<value>[a-zA-Z]+)$/',
+            'permutations.alphaLowercase'     => '/^\/permutations\/alpha-lowercase\/(?<value>[a-z]+)$/',
+            'permutations.alphaUppercase'     => '/^\/permutations\/alpha-uppercase\/(?<value>[A-Z]+)$/',
+            'permutations.alphaNum'           => '/^\/permutations\/alpha-num\/(?<value>[a-zA-Z0-9]+)$/',
+            'permutations.alphaNumUnderscore' => '/^\/permutations\/alpha-num-underscore\/(?<value>\w+)$/',
+            'permutations.any'                => '/^\/permutations\/any\/(?<value>.*)$/',
+            'permutations.multi'              => '/^\/permutations\/multi\/(?<first>\d+)\/(?<second>[a-zA-Z]+)$/',
+            // A non-capturing parameter produces a group without a name.
+            'permutations.nonCapture'         => '/^\/permutations\/non-capture\/(?:[a-zA-Z]+)$/',
+            // An optional parameter makes the preceding slash optional too.
+            'permutations.optional'           => '/^\/permutations\/optional(?:\/)?(?<value>[a-zA-Z]+)?$/',
+        ];
+
+        foreach ($expected as $name => $regex) {
+            self::assertArrayHasKey($name, $data->routes, "Route '$name' was not generated");
+            self::assertArrayHasKey($regex, $data->regexes['GET'], "Regex for '$name' was not generated");
+            self::assertSame($name, $data->regexes['GET'][$regex]);
+        }
+
+        // The static permutations are registered as paths rather than regexes.
+        self::assertArrayHasKey('/permutations/static', $data->paths['GET']);
+        self::assertSame('permutations.static', $data->paths['GET']['/permutations/static']);
+
+        // A method-restricted route is only registered under that method.
+        self::assertArrayHasKey('/permutations/post', $data->paths['POST']);
+        self::assertArrayNotHasKey('/permutations/post', $data->paths['GET']);
+
+        // A route declared for any method is registered under every method.
+        self::assertArrayHasKey('/permutations/any-method', $data->paths['GET']);
+        self::assertArrayHasKey('/permutations/any-method', $data->paths['POST']);
+        self::assertArrayHasKey('/permutations/any-method', $data->paths['DELETE']);
     }
 }

--- a/app/src/App/Http/Controller/RoutingPermutationsController.php
+++ b/app/src/App/Http/Controller/RoutingPermutationsController.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Http\Controller;
+
+use App\Http\Controller\Abstract\Controller;
+use App\Http\Provider\HttpRouteProvider;
+use Valkyrja\Http\Message\Enum\RequestMethod;
+use Valkyrja\Http\Message\Response\Contract\TextResponseContract;
+use Valkyrja\Http\Message\Response\TextResponse;
+use Valkyrja\Http\Routing\Attribute\Parameter;
+use Valkyrja\Http\Routing\Attribute\Route;
+use Valkyrja\Http\Routing\Attribute\Route\RouteHandler;
+use Valkyrja\Http\Routing\Constant\Regex;
+
+/**
+ * Demonstrates every routing permutation the framework supports.
+ *
+ * Each route echoes back the value(s) bound to its parameters so the produced regex,
+ * the match, and the parameter binding can all be asserted end to end. Paths are
+ * namespaced under /permutations so they never collide with the catch-all
+ * `/{value}` route on HomeController.
+ */
+class RoutingPermutationsController extends Controller
+{
+    /**
+     * A numeric parameter.
+     */
+    #[Route(path: '/permutations/num/{value}', name: 'permutations.num')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsNumHandler'])]
+    public function num(
+        #[Parameter(name: 'value', regex: Regex::NUM)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * An id parameter.
+     */
+    #[Route(path: '/permutations/id/{value}', name: 'permutations.id')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsIdHandler'])]
+    public function id(
+        #[Parameter(name: 'value', regex: Regex::ID)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * A slug parameter.
+     */
+    #[Route(path: '/permutations/slug/{value}', name: 'permutations.slug')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsSlugHandler'])]
+    public function slug(
+        #[Parameter(name: 'value', regex: Regex::SLUG)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * An alphabetic parameter.
+     */
+    #[Route(path: '/permutations/alpha/{value}', name: 'permutations.alpha')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsAlphaHandler'])]
+    public function alpha(
+        #[Parameter(name: 'value', regex: Regex::ALPHA)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * A lowercase alphabetic parameter.
+     */
+    #[Route(path: '/permutations/alpha-lowercase/{value}', name: 'permutations.alphaLowercase')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsAlphaLowercaseHandler'])]
+    public function alphaLowercase(
+        #[Parameter(name: 'value', regex: Regex::ALPHA_LOWERCASE)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * An uppercase alphabetic parameter.
+     */
+    #[Route(path: '/permutations/alpha-uppercase/{value}', name: 'permutations.alphaUppercase')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsAlphaUppercaseHandler'])]
+    public function alphaUppercase(
+        #[Parameter(name: 'value', regex: Regex::ALPHA_UPPERCASE)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * An alphanumeric parameter.
+     */
+    #[Route(path: '/permutations/alpha-num/{value}', name: 'permutations.alphaNum')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsAlphaNumHandler'])]
+    public function alphaNum(
+        #[Parameter(name: 'value', regex: Regex::ALPHA_NUM)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * An alphanumeric parameter that also allows underscores.
+     */
+    #[Route(path: '/permutations/alpha-num-underscore/{value}', name: 'permutations.alphaNumUnderscore')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsAlphaNumUnderscoreHandler'])]
+    public function alphaNumUnderscore(
+        #[Parameter(name: 'value', regex: Regex::ALPHA_NUM_UNDERSCORE)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * A parameter that matches anything.
+     */
+    #[Route(path: '/permutations/any/{value}', name: 'permutations.any')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsAnyHandler'])]
+    public function any(
+        #[Parameter(name: 'value', regex: Regex::ANY)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * A uuid parameter.
+     */
+    #[Route(path: '/permutations/uuid/{value}', name: 'permutations.uuid')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsUuidHandler'])]
+    public function uuid(
+        #[Parameter(name: 'value', regex: Regex::UUID)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * A ulid parameter.
+     */
+    #[Route(path: '/permutations/ulid/{value}', name: 'permutations.ulid')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsUlidHandler'])]
+    public function ulid(
+        #[Parameter(name: 'value', regex: Regex::ULID)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * A vlid parameter.
+     */
+    #[Route(path: '/permutations/vlid/{value}', name: 'permutations.vlid')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsVlidHandler'])]
+    public function vlid(
+        #[Parameter(name: 'value', regex: Regex::VLID)]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * An optional parameter that falls back to its default when absent.
+     */
+    #[Route(path: '/permutations/optional/{value?}', name: 'permutations.optional')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsOptionalHandler'])]
+    public function optional(
+        #[Parameter(name: 'value', regex: Regex::ALPHA, isOptional: true, default: 'default')]
+        string $value
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * Multiple parameters separated by a static segment.
+     */
+    #[Route(path: '/permutations/multi/{first}/{second}', name: 'permutations.multi')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsMultiHandler'])]
+    public function multi(
+        #[Parameter(name: 'first', regex: Regex::NUM)]
+        string $first,
+        #[Parameter(name: 'second', regex: Regex::ALPHA)]
+        string $second
+    ): TextResponseContract {
+        return new TextResponse("$first-$second");
+    }
+
+    /**
+     * A parameter that is matched but deliberately not captured.
+     */
+    #[Route(path: '/permutations/non-capture/{value}', name: 'permutations.nonCapture')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsNonCaptureHandler'])]
+    public function nonCapture(
+        #[Parameter(name: 'value', regex: Regex::ALPHA, shouldCapture: false)]
+        string $value = 'non-capture'
+    ): TextResponseContract {
+        return new TextResponse($value);
+    }
+
+    /**
+     * A route with no parameters at all.
+     */
+    #[Route(path: '/permutations/static', name: 'permutations.static')]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsStaticHandler'])]
+    public function staticRoute(): TextResponseContract
+    {
+        return new TextResponse('static');
+    }
+
+    /**
+     * A route restricted to a single request method.
+     */
+    #[Route(path: '/permutations/post', name: 'permutations.post', requestMethods: [RequestMethod::POST])]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsPostHandler'])]
+    public function post(): TextResponseContract
+    {
+        return new TextResponse('post');
+    }
+
+    /**
+     * A route that answers to every request method.
+     */
+    #[Route(path: '/permutations/any-method', name: 'permutations.anyMethod', requestMethods: [RequestMethod::ANY])]
+    #[RouteHandler([HttpRouteProvider::class, 'permutationsAnyMethodHandler'])]
+    public function anyMethod(): TextResponseContract
+    {
+        return new TextResponse('any-method');
+    }
+}

--- a/app/src/App/Http/Provider/HttpRouteProvider.php
+++ b/app/src/App/Http/Provider/HttpRouteProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Http\Provider;
 
 use App\Http\Controller\HomeController;
+use App\Http\Controller\RoutingPermutationsController;
 use Override;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
@@ -82,6 +83,124 @@ final class HttpRouteProvider implements HttpRouteProviderContract
         );
     }
 
+    public static function permutationsNumHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->num(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsIdHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->id(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsSlugHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->slug(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsAlphaHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->alpha(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsAlphaLowercaseHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->alphaLowercase(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsAlphaUppercaseHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->alphaUppercase(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsAlphaNumHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->alphaNum(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsAlphaNumUnderscoreHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->alphaNumUnderscore(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsAnyHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->any(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsUuidHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->uuid(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsUlidHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->ulid(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsVlidHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->vlid(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsOptionalHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->optional(self::permutationValue($route, 'value'));
+    }
+
+    public static function permutationsMultiHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->multi(
+            self::permutationValue($route, 'first'),
+            self::permutationValue($route, 'second')
+        );
+    }
+
+    public static function permutationsNonCaptureHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        // The parameter is matched but not captured, so the controller default is used.
+        return self::permutationsController($container)->nonCapture();
+    }
+
+    public static function permutationsStaticHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->staticRoute();
+    }
+
+    public static function permutationsPostHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->post();
+    }
+
+    public static function permutationsAnyMethodHandler(ContainerContract $container, RouteContract $route): ResponseContract
+    {
+        return self::permutationsController($container)->anyMethod();
+    }
+
+    /**
+     * Get the routing permutations controller.
+     */
+    private static function permutationsController(ContainerContract $container): RoutingPermutationsController
+    {
+        return $container->getSingleton(RoutingPermutationsController::class);
+    }
+
+    /**
+     * Get a bound parameter's value from a dynamic route.
+     *
+     * @param non-empty-string $name The parameter name
+     */
+    private static function permutationValue(RouteContract $route, string $name): string
+    {
+        /**
+         * @var DynamicRouteContract $route
+         * @var string               $value
+         */
+        $value = $route->getParameter($name)->getValue();
+
+        return $value;
+    }
+
     /**
      * @inheritDoc
      */
@@ -90,6 +209,7 @@ final class HttpRouteProvider implements HttpRouteProviderContract
     {
         return [
             HomeController::class,
+            RoutingPermutationsController::class,
         ];
     }
 

--- a/app/src/App/Http/Provider/ServiceProvider.php
+++ b/app/src/App/Http/Provider/ServiceProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Http\Provider;
 
 use App\Http\Controller\HomeController;
+use App\Http\Controller\RoutingPermutationsController;
 use Override;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
@@ -37,13 +38,28 @@ final class ServiceProvider implements ServiceProviderContract
     }
 
     /**
+     * Publish the routing permutations controller.
+     */
+    public static function publishRoutingPermutationsController(ContainerContract $container): void
+    {
+        $container->setSingleton(
+            RoutingPermutationsController::class,
+            new RoutingPermutationsController(
+                $container->getSingleton(ServerRequestContract::class),
+                $container->getSingleton(ResponseFactoryContract::class)
+            )
+        );
+    }
+
+    /**
      * @inheritDoc
      */
     #[Override]
     public function publishers(): array
     {
         return [
-            HomeController::class => [self::class, 'publishHomeController'],
+            HomeController::class                => [self::class, 'publishHomeController'],
+            RoutingPermutationsController::class => [self::class, 'publishRoutingPermutationsController'],
         ];
     }
 }

--- a/app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php
+++ b/app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php
@@ -23,6 +23,7 @@ use function fsockopen;
 use function getenv;
 use function is_resource;
 use function microtime;
+use function preg_match;
 use function proc_close;
 use function proc_get_status;
 use function proc_open;
@@ -161,6 +162,46 @@ abstract class RuntimeServerTestCase extends TestCase
         }
 
         return $body;
+    }
+
+    /**
+     * Perform a request against the running server and return its status code and body.
+     *
+     * @param non-empty-string $method The request method
+     *
+     * @return array{status: int, body: string}
+     */
+    protected function httpRequest(string $path, string $method = 'GET'): array
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method'        => $method,
+                'ignore_errors' => true,
+                'timeout'       => 5,
+            ],
+        ]);
+
+        $body = @file_get_contents("http://127.0.0.1:{$this->port}{$path}", false, $context);
+
+        if ($body === false) {
+            self::fail("Request to $path failed:\n" . $this->drainOutput());
+        }
+
+        $status = 0;
+
+        /** @var string[] $responseHeaders file_get_contents populates this in the local scope */
+        $responseHeaders = $http_response_header ?? [];
+
+        foreach ($responseHeaders as $header) {
+            if (preg_match('/^HTTP\/[\d.]+\s+(\d{3})/', $header, $matches) === 1) {
+                $status = (int) $matches[1];
+            }
+        }
+
+        return [
+            'status' => $status,
+            'body'   => $body,
+        ];
     }
 
     /**

--- a/app/tests/Tests/Functional/Entry/HttpPermutationRoutesEntryTest.php
+++ b/app/tests/Tests/Functional/Entry/HttpPermutationRoutesEntryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional\Entry;
+
+use App\Tests\Functional\Abstract\RuntimeServerTestCase;
+
+use const PHP_BINARY;
+
+/**
+ * End-to-end test for every routing permutation the application defines.
+ *
+ * Serves `app/public` through PHP's built-in web server and drives a real HTTP
+ * request for each permutation, asserting the route matches, binds its
+ * parameter(s), and echoes the expected body — and that values which must not
+ * match are rejected. This runs against the sindri-generated routing data, so it
+ * proves the generated cache routes exactly as the framework does at runtime.
+ */
+final class HttpPermutationRoutesEntryTest extends RuntimeServerTestCase
+{
+    private const string UUID = '66a39476-b630-4b95-8bfb-355f3d4843c5';
+    private const string ULID = '01KYGBV64MKWPK63CC1QH0VGF7';
+    private const string VLID = '04YHJMN6F5XHM497ZW';
+
+    public function testServesEveryRoutingPermutationOverHttp(): void
+    {
+        $this->port = $this->findFreePort();
+
+        $this->startServer([
+            PHP_BINARY,
+            '-S',
+            "127.0.0.1:{$this->port}",
+            '-t',
+            'app/public',
+        ]);
+
+        // Each permutation echoes the value bound to its parameter(s).
+        $matches = [
+            'num'                  => ['/permutations/num/42', '42'],
+            'id'                   => ['/permutations/id/7', '7'],
+            'slug'                 => ['/permutations/slug/my-slug-1', 'my-slug-1'],
+            'alpha'                => ['/permutations/alpha/abc', 'abc'],
+            'alpha lowercase'      => ['/permutations/alpha-lowercase/abc', 'abc'],
+            'alpha uppercase'      => ['/permutations/alpha-uppercase/ABC', 'ABC'],
+            'alpha num'            => ['/permutations/alpha-num/abc123', 'abc123'],
+            'alpha num underscore' => ['/permutations/alpha-num-underscore/abc_123', 'abc_123'],
+            'any'                  => ['/permutations/any/anything-1.x', 'anything-1.x'],
+            'uuid'                 => ['/permutations/uuid/' . self::UUID, self::UUID],
+            'ulid'                 => ['/permutations/ulid/' . self::ULID, self::ULID],
+            'vlid'                 => ['/permutations/vlid/' . self::VLID, self::VLID],
+            'multi parameters'     => ['/permutations/multi/12/two', '12-two'],
+            // The parameter matches but is not captured, so the default is used.
+            'non capture'          => ['/permutations/non-capture/abc', 'non-capture'],
+            // An absent optional parameter falls back to its default.
+            'optional absent'      => ['/permutations/optional', 'default'],
+            'optional present'     => ['/permutations/optional/present', 'present'],
+            'static'               => ['/permutations/static', 'static'],
+            'any method'           => ['/permutations/any-method', 'any-method'],
+        ];
+
+        foreach ($matches as $label => [$path, $expected]) {
+            $response = $this->httpRequest($path);
+
+            self::assertSame(200, $response['status'], "The $label route did not match $path");
+            self::assertSame($expected, $response['body'], "The $label route returned an unexpected body");
+        }
+
+        // A value that does not satisfy the parameter's regex must not match.
+        $rejections = [
+            'num rejects alpha'                 => '/permutations/num/abc',
+            'alpha rejects a digit'             => '/permutations/alpha/abc1',
+            'alpha lowercase rejects uppercase' => '/permutations/alpha-lowercase/Abc',
+            'alpha uppercase rejects lowercase' => '/permutations/alpha-uppercase/abc',
+            'alpha num rejects a hyphen'        => '/permutations/alpha-num/abc-1',
+            'uuid rejects a non uuid'           => '/permutations/uuid/not-a-uuid',
+            'ulid rejects a non ulid'           => '/permutations/ulid/notaulid',
+        ];
+
+        foreach ($rejections as $label => $path) {
+            self::assertSame(404, $this->httpRequest($path)['status'], "The $label case unexpectedly matched");
+        }
+
+        // A route restricted to POST answers POST, and rejects GET as method not allowed.
+        $post = $this->httpRequest('/permutations/post', 'POST');
+
+        self::assertSame(200, $post['status']);
+        self::assertSame('post', $post['body']);
+        self::assertSame(405, $this->httpRequest('/permutations/post')['status']);
+
+        // A route declared for any method answers a method it never named explicitly.
+        $anyMethod = $this->httpRequest('/permutations/any-method', 'DELETE');
+
+        self::assertSame(200, $anyMethod['status']);
+        self::assertSame('any-method', $anyMethod['body']);
+    }
+}

--- a/app/tests/Tests/Unit/Http/Controller/RoutingPermutationsControllerTest.php
+++ b/app/tests/Tests/Unit/Http/Controller/RoutingPermutationsControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Application package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Http\Controller;
+
+use App\Http\Controller\RoutingPermutationsController;
+use Closure;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Response\Contract\TextResponseContract;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
+
+final class RoutingPermutationsControllerTest extends TestCase
+{
+    private RoutingPermutationsController $controller;
+
+    /**
+     * Every parameter-type route echoes the value bound to its parameter.
+     *
+     * @return array<non-empty-string, array{Closure(RoutingPermutationsController, non-empty-string): TextResponseContract, non-empty-string}>
+     */
+    public static function parameterTypeProvider(): array
+    {
+        return [
+            'num'                  => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->num($v), '42'],
+            'id'                   => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->id($v), '7'],
+            'slug'                 => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->slug($v), 'my-slug-1'],
+            'alpha'                => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->alpha($v), 'abc'],
+            'alpha lowercase'      => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->alphaLowercase($v), 'abc'],
+            'alpha uppercase'      => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->alphaUppercase($v), 'ABC'],
+            'alpha num'            => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->alphaNum($v), 'abc123'],
+            'alpha num underscore' => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->alphaNumUnderscore($v), 'abc_123'],
+            'any'                  => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->any($v), 'anything-1.x'],
+            'uuid'                 => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->uuid($v), '66a39476-b630-4b95-8bfb-355f3d4843c5'],
+            'ulid'                 => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->ulid($v), '01KYGBV64MKWPK63CC1QH0VGF7'],
+            'vlid'                 => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->vlid($v), '04YHJMN6F5XHM497ZW'],
+            'optional'             => [static fn (RoutingPermutationsController $c, string $v): TextResponseContract => $c->optional($v), 'present'],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->controller = new RoutingPermutationsController(
+            self::createStub(ServerRequestContract::class),
+            self::createStub(ResponseFactoryContract::class)
+        );
+    }
+
+    /**
+     * @param Closure(RoutingPermutationsController, non-empty-string): TextResponseContract $action
+     * @param non-empty-string                                                               $value
+     */
+    #[DataProvider('parameterTypeProvider')]
+    public function testParameterTypeRouteEchoesValue(Closure $action, string $value): void
+    {
+        $response = $action($this->controller, $value);
+
+        self::assertInstanceOf(TextResponseContract::class, $response);
+        self::assertSame($value, (string) $response->getBody());
+    }
+
+    public function testMultiCombinesBothParameters(): void
+    {
+        $response = $this->controller->multi('12', 'two');
+
+        self::assertInstanceOf(TextResponseContract::class, $response);
+        self::assertSame('12-two', (string) $response->getBody());
+    }
+
+    public function testNonCaptureFallsBackToItsDefault(): void
+    {
+        $response = $this->controller->nonCapture();
+
+        self::assertInstanceOf(TextResponseContract::class, $response);
+        self::assertSame('non-capture', (string) $response->getBody());
+    }
+
+    public function testStaticRouteReturnsItsText(): void
+    {
+        $response = $this->controller->staticRoute();
+
+        self::assertInstanceOf(TextResponseContract::class, $response);
+        self::assertSame('static', (string) $response->getBody());
+    }
+
+    public function testPostReturnsItsText(): void
+    {
+        $response = $this->controller->post();
+
+        self::assertInstanceOf(TextResponseContract::class, $response);
+        self::assertSame('post', (string) $response->getBody());
+    }
+
+    public function testAnyMethodReturnsItsText(): void
+    {
+        $response = $this->controller->anyMethod();
+
+        self::assertInstanceOf(TextResponseContract::class, $response);
+        self::assertSame('any-method', (string) $response->getBody());
+    }
+}

--- a/app/tests/Tests/Unit/Http/Provider/HttpRouteProviderTest.php
+++ b/app/tests/Tests/Unit/Http/Provider/HttpRouteProviderTest.php
@@ -14,10 +14,14 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Http\Provider;
 
 use App\Http\Controller\HomeController;
+use App\Http\Controller\RoutingPermutationsController;
 use App\Http\Provider\HttpRouteProvider;
+use Closure;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Manager\Container;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 use Valkyrja\Http\Message\Response\Contract\JsonResponseContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
@@ -33,6 +37,45 @@ final class HttpRouteProviderTest extends TestCase
     private Container $container;
 
     private RouteContract $route;
+
+    /**
+     * Every single-parameter permutation handler binds the route's value and echoes it.
+     *
+     * @return array<non-empty-string, array{Closure(ContainerContract, RouteContract): ResponseContract, non-empty-string}>
+     */
+    public static function permutationHandlerProvider(): array
+    {
+        return [
+            'num'                  => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsNumHandler($c, $r), '42'],
+            'id'                   => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsIdHandler($c, $r), '7'],
+            'slug'                 => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsSlugHandler($c, $r), 'my-slug-1'],
+            'alpha'                => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsAlphaHandler($c, $r), 'abc'],
+            'alpha lowercase'      => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsAlphaLowercaseHandler($c, $r), 'abc'],
+            'alpha uppercase'      => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsAlphaUppercaseHandler($c, $r), 'ABC'],
+            'alpha num'            => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsAlphaNumHandler($c, $r), 'abc123'],
+            'alpha num underscore' => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsAlphaNumUnderscoreHandler($c, $r), 'abc_123'],
+            'any'                  => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsAnyHandler($c, $r), 'anything-1.x'],
+            'uuid'                 => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsUuidHandler($c, $r), '66a39476-b630-4b95-8bfb-355f3d4843c5'],
+            'ulid'                 => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsUlidHandler($c, $r), '01KYGBV64MKWPK63CC1QH0VGF7'],
+            'vlid'                 => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsVlidHandler($c, $r), '04YHJMN6F5XHM497ZW'],
+            'optional'             => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsOptionalHandler($c, $r), 'present'],
+        ];
+    }
+
+    /**
+     * Every parameterless permutation handler returns its fixed text.
+     *
+     * @return array<non-empty-string, array{Closure(ContainerContract, RouteContract): ResponseContract, non-empty-string}>
+     */
+    public static function staticPermutationHandlerProvider(): array
+    {
+        return [
+            'non capture' => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsNonCaptureHandler($c, $r), 'non-capture'],
+            'static'      => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsStaticHandler($c, $r), 'static'],
+            'post'        => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsPostHandler($c, $r), 'post'],
+            'any method'  => [static fn (ContainerContract $c, RouteContract $r): ResponseContract => HttpRouteProvider::permutationsAnyMethodHandler($c, $r), 'any-method'],
+        ];
+    }
 
     protected function setUp(): void
     {
@@ -53,6 +96,10 @@ final class HttpRouteProviderTest extends TestCase
         $this->container->setSingleton(
             HomeController::class,
             new HomeController(self::createStub(ServerRequestContract::class), $responseFactory)
+        );
+        $this->container->setSingleton(
+            RoutingPermutationsController::class,
+            new RoutingPermutationsController(self::createStub(ServerRequestContract::class), $responseFactory)
         );
 
         $this->route = self::createStub(RouteContract::class);
@@ -99,13 +146,73 @@ final class HttpRouteProviderTest extends TestCase
         self::assertInstanceOf(ResponseContract::class, HttpRouteProvider::jsonHandler($this->container, $this->route));
     }
 
+    /**
+     * @param Closure(ContainerContract, RouteContract): ResponseContract $handler
+     * @param non-empty-string                                            $value
+     */
+    #[DataProvider('permutationHandlerProvider')]
+    public function testPermutationHandlerEchoesBoundValue(Closure $handler, string $value): void
+    {
+        $response = $handler($this->container, $this->dynamicRouteWithValues(['value' => $value]));
+
+        self::assertInstanceOf(ResponseContract::class, $response);
+        self::assertSame($value, (string) $response->getBody());
+    }
+
+    /**
+     * @param Closure(ContainerContract, RouteContract): ResponseContract $handler
+     * @param non-empty-string                                            $expected
+     */
+    #[DataProvider('staticPermutationHandlerProvider')]
+    public function testStaticPermutationHandlerReturnsItsText(Closure $handler, string $expected): void
+    {
+        $response = $handler($this->container, $this->route);
+
+        self::assertInstanceOf(ResponseContract::class, $response);
+        self::assertSame($expected, (string) $response->getBody());
+    }
+
+    public function testPermutationsMultiHandlerBindsBothParameters(): void
+    {
+        $route = $this->dynamicRouteWithValues(['first' => '12', 'second' => 'two']);
+
+        $response = HttpRouteProvider::permutationsMultiHandler($this->container, $route);
+
+        self::assertInstanceOf(ResponseContract::class, $response);
+        self::assertSame('12-two', (string) $response->getBody());
+    }
+
     public function testGetControllerClasses(): void
     {
-        self::assertSame([HomeController::class], new HttpRouteProvider()->getControllerClasses());
+        self::assertSame(
+            [HomeController::class, RoutingPermutationsController::class],
+            new HttpRouteProvider()->getControllerClasses()
+        );
     }
 
     public function testGetRoutes(): void
     {
         self::assertSame([], new HttpRouteProvider()->getRoutes());
+    }
+
+    /**
+     * Build a dynamic route whose parameters resolve to the given name => value pairs.
+     *
+     * @param array<non-empty-string, non-empty-string> $values
+     */
+    private function dynamicRouteWithValues(array $values): DynamicRouteContract
+    {
+        $route = self::createStub(DynamicRouteContract::class);
+        $route->method('getParameter')
+            ->willReturnCallback(
+                static function (string $name) use ($values): ParameterContract {
+                    $parameter = self::createStub(ParameterContract::class);
+                    $parameter->method('getValue')->willReturn($values[$name] ?? null);
+
+                    return $parameter;
+                }
+            );
+
+        return $route;
     }
 }

--- a/app/tests/Tests/Unit/Http/Provider/ServiceProviderTest.php
+++ b/app/tests/Tests/Unit/Http/Provider/ServiceProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Http\Provider;
 
 use App\Http\Controller\HomeController;
+use App\Http\Controller\RoutingPermutationsController;
 use App\Http\Provider\ServiceProvider;
 use PHPUnit\Framework\TestCase;
 use Valkyrja\Container\Manager\Container;
@@ -33,11 +34,26 @@ final class ServiceProviderTest extends TestCase
         self::assertInstanceOf(HomeController::class, $container->getSingleton(HomeController::class));
     }
 
+    public function testPublishRoutingPermutationsController(): void
+    {
+        $container = new Container();
+        $container->setSingleton(ServerRequestContract::class, self::createStub(ServerRequestContract::class));
+        $container->setSingleton(ResponseFactoryContract::class, self::createStub(ResponseFactoryContract::class));
+
+        ServiceProvider::publishRoutingPermutationsController($container);
+
+        self::assertInstanceOf(
+            RoutingPermutationsController::class,
+            $container->getSingleton(RoutingPermutationsController::class)
+        );
+    }
+
     public function testPublishers(): void
     {
         self::assertSame(
             [
-                HomeController::class => [ServiceProvider::class, 'publishHomeController'],
+                HomeController::class                => [ServiceProvider::class, 'publishHomeController'],
+                RoutingPermutationsController::class => [ServiceProvider::class, 'publishRoutingPermutationsController'],
             ],
             new ServiceProvider()->publishers(),
         );


### PR DESCRIPTION
# Description

Adds one route per routing permutation to the example application, each covered by
regression, smoke, and end-to-end tests, so a framework release that changed routing
behavior would fail here rather than silently reaching applications.

Every permutation lives on a dedicated `RoutingPermutationsController`, namespaced under
`/permutations/…` so the paths can never be shadowed by the catch-all `/{value}` route on
`HomeController`, and each route simply echoes the value(s) bound to its parameters so the
binding is directly assertable over the wire.

**The permutations** — twelve parameter types (`NUM`, `ID`, `SLUG`, `ALPHA`,
`ALPHA_LOWERCASE`, `ALPHA_UPPERCASE`, `ALPHA_NUM`, `ALPHA_NUM_UNDERSCORE`, `ANY`, `UUID`,
`ULID`, `VLID`) plus an optional parameter, multiple parameters, a non-capturing parameter,
a static route, a method-restricted route, and a route declared for any method.

**Three tiers of coverage**, matching the tiers the repository already has:

1. **Regression (unit)** — the controller returns the expected body for each permutation,
   and each provider handler binds the route's parameter(s) and delegates correctly.
2. **Generated data (`sindri-phpunit`)** — asserts the *sindri-generated* routing table
   contains each permutation with the **exact** regex the framework's processor produces,
   that a non-capturing parameter yields an unnamed group, that an optional parameter makes
   the preceding slash optional, that static permutations are registered as paths rather
   than regexes, that a method-restricted route appears only under its own method, and that
   an any-method route appears under every method. This is what proves the cached routing
   table matches runtime.
3. **Smoke / end-to-end** — a real HTTP request per permutation through PHP's built-in
   server against `app/public`, asserting status and body: every permutation matches and
   echoes its bound value, values that must not match are rejected with `404`, a `POST`-only
   route answers `POST` and rejects `GET` with `405`, and an any-method route answers
   `DELETE`.

`RuntimeServerTestCase` gained an `httpRequest()` helper returning status **and** body (the
existing `httpGet()` returns only a body), so end-to-end tests can assert status codes.

## Found while writing these tests

- **`RequestMethod::ANY` was broken in the generated cache** — sindri keyed such routes under
  a literal `ANY` rather than expanding them to every concrete method, so a cached any-method
  route could never be matched. Fixed in valkyrjaio/sindri-php#173. **This PR's
  `sindri-phpunit` job stays red until that fix is merged and released**, since the
  application consumes a released `valkyrja/sindri`.
- **A missing `errors/405` view** made every method-mismatch request crash with an uncaught
  `ViewInvalidPathException`. Fixed separately in #172, which this PR is based on — retarget
  to `26.x` once that merges.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`app/src/App/Http/Controller/RoutingPermutationsController.php`** — new controller declaring one attribute-defined route per routing permutation, each echoing its bound parameter value(s).
- **`app/src/App/Http/Provider/HttpRouteProvider.php`** — added a handler per permutation route plus shared helpers to resolve the controller and read a bound parameter, and registered the new controller for attribute collection.
- **`app/src/App/Http/Provider/ServiceProvider.php`** — published the new controller so the container can resolve it.
- **`app/tests/Tests/Functional/Abstract/RuntimeServerTestCase.php`** — added `httpRequest()` returning status and body so end-to-end tests can assert status codes.
- **`app/tests/Tests/Functional/Entry/HttpPermutationRoutesEntryTest.php`** — new end-to-end test driving a real HTTP request for every permutation, including rejections, the method restriction, and the any-method route.
- **`app/tests/Tests/Unit/Http/Controller/RoutingPermutationsControllerTest.php`** — new regression test for every controller action.
- **`app/tests/Tests/Unit/Http/Provider/HttpRouteProviderTest.php`** — added regression tests for every permutation handler's parameter binding and delegation.
- **`app/tests/Tests/Unit/Http/Provider/ServiceProviderTest.php`** — covered publishing the new controller.
- **`.github/ci/sindri-phpunit/tests/Http/Data/AppHttpRoutingDataTest.php`** — asserts the generated routing table contains every permutation with its exact regex and correct method registration.
- **`.github/ci/sindri-phpunit/tests/Cli/Data/AppHttpRoutingDataTest.php`** — updated the generated route count for the CLI entry point's copy of the HTTP routing data.
