### PR TITLE
[Composer] Drop spiral/roadrunner-http v3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require-dev"       : {
     "filp/whoops": "^2.18.4",
     "spiral/roadrunner-cli": "^2.6",
-    "spiral/roadrunner-http": "^3.5 || ^4.0",
+    "spiral/roadrunner-http": "^4.1.0",
     "valkyrja/sindri": "^26.5.2"
   },
   "config"            : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc34d3ad74ac0ded3c5c172fdd9a14e1",
+    "content-hash": "8e590463ca4b69ff5e2223e700300883",
     "packages": [
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
# Description

`spiral/roadrunner-http` was the only composite version constraint left anywhere in
the organization — a sweep of all 11 PHP repos that run the shared
update-dependencies workflow (86 `composer.json` files across `require`,
`require-dev`, and `conflict`) turned up no other one. It is also the constraint
that broke the nightly dependency job here:
<https://github.com/valkyrjaio/valkyrja-starter-app-php/actions/runs/30265190461>
(fixed separately in valkyrjaio/.github#137).

Supporting v3.5 no longer buys anything:

- **This is a starter app, not a library.** There is no consumer dependency graph
  to stay flexible for; the repo pins every other dependency to a single
  `^x.y.z`, so the composite constraint was the outlier.
- **The framework already recommends v4.** `valkyrja/valkyrja`'s `suggest` entry
  reads `Required to use the RoadRunner worker entry point (^4.1.0)`.
- **v4.0.0's only break does not affect us.** It added `$endOfStream` to
  `HttpWorkerInterface::respond()` and removed deprecations. Everything
  `Valkyrja\Application\Entry\RoadRunner\RoadRunnerHttp` touches —
  `HttpWorker::waitRequest()`, `HttpWorker::respond()`, and `Request`'s
  `query` / `cookies` / `uploads` / `body` / `getParsedBody()` — is byte-identical
  between v3.5.2 and v4.1.0. So v3 was supported only in the sense that nothing
  had broken it yet, not because it was exercised anywhere.
- **The constraint would otherwise freeze.** With valkyrjaio/.github#137 the sync
  step deliberately leaves composite constraints alone rather than silently
  collapsing them, so this one would never be bumped again by the nightly job.

The lock file already resolved to `v4.1.0`, so this narrows the declared floor to
match what is actually installed and tested; the resolved package set is unchanged
and only `content-hash` moves.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`composer.json`** — narrowed `require-dev` `spiral/roadrunner-http` from
  `^3.5 || ^4.0` to `^4.1.0`, matching the locked and tested version
- **`composer.lock`** — refreshed `content-hash` for the new constraint; no
  package versions changed
