### PR TITLE
[GitHub] Use the PHP release workflow for releases

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -20,7 +20,19 @@ permissions:
 
 jobs:
   release:
-    uses: valkyrjaio/.github/.github/workflows/_create-release.yml@716065aae4466b95f0f80c9c5a5e2a92de620af6
+    uses: valkyrjaio/.github/.github/workflows/_php-create-release.yml@95e2c292cc5cf9b80ae40e02bedd74d7d1428b12
     secrets: inherit
     with:
       bump: ${{ inputs.bump }}
+      dependencies: |
+        [
+          {"name": "Root Packages",   "command": "root-outdated-check"},
+          {"name": "PHPArkitect",     "command": "phparkitect-outdated-check"},
+          {"name": "PHPCodeSniffer",  "command": "phpcodesniffer-outdated-check"},
+          {"name": "PHP-CS-Fixer",    "command": "phpcsfixer-outdated-check"},
+          {"name": "PHPStan",         "command": "phpstan-outdated-check"},
+          {"name": "PHPUnit",         "command": "phpunit-outdated-check"},
+          {"name": "Psalm",           "command": "psalm-outdated-check"},
+          {"name": "Rector",          "command": "rector-outdated-check"},
+          {"name": "Sindri PHPUnit",  "command": "sindri-phpunit-outdated-check"}
+        ]


### PR DESCRIPTION
# Description

This repo releases through the generic `_create-release.yml` while
`valkyrja-starter-app-ts` uses its language-specific `_ts-create-release.yml`. That
was never a decision about starter apps — `_php-create-release.yml` declared
`info-class-path` / `info-class-name` as `required: true`, this repo has no Info
class, and calling the workflow without them produced an invalid-workflow error. The
generic workflow was the workaround.

[valkyrjaio/.github#146](https://github.com/valkyrjaio/.github/pull/146) removed that
blocker by making both inputs optional in the PHP and Java release workflows —
mirroring what [#95](https://github.com/valkyrjaio/.github/pull/95) did for
TypeScript over a year ago for this exact reason. So this switches over and simply
omits the info inputs; the `update-php-info-files` job skips itself when the path is
empty, and the release proceeds.

The gain is the **outdated-dependency gate**: `_php-create-release.yml` runs
`_php-check-outdated-dependencies.yml` before releasing, which the generic workflow
does not. Releases now fail if any dependency is behind, the same standard
`valkyrja-php` and `sindri-php` are held to.

No Info class is added. Version metadata belongs to a library that reports it, not to
an application, and that asymmetry is deliberate — `valkyrja-starter-app-ts` has none
either.

## On the dependency list

Unlike the Java side, this could not be copied from this repo's
`update-dependencies.yml`: that workflow takes composer *update* scripts, while the
release gate takes `*-outdated-check` scripts. The list is built from this repo's own
`composer.json` rather than from `valkyrja-php`'s, which matters in two places —
this repo has `root-outdated-check` where the framework has
`root-and-suggested-outdated-check`, and it has an extra `sindri-phpunit` tool the
framework does not. Every one of the nine scripts is verified to exist (see below).

## Note on scope of the gate

The list includes `root-outdated-check`, so a release is now gated on **the
application's own dependencies** being current, not just the CI tooling. That is the
same standard the framework repos use, and the daily dependency workflow already
keeps these current — but it is stricter than today, where nothing is checked at all.
Easy to narrow to CI tooling only by dropping the `Root Packages` entry if that is
too strict for an example app.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`.github/workflows/release-new-version.yml`** — switched from
  `_create-release.yml` to `_php-create-release.yml`, adding the `dependencies` list
  covering the root packages and all eight CI tool directories.

## Verification

- Inputs checked against `_php-create-release.yml`'s declared `workflow_call` inputs
  at the pinned commit: required inputs are now `bump` and `dependencies` only — both
  passed — with no unknown inputs. `info-class-path` and `info-class-name` are
  confirmed `default: ''` at that SHA, which is what makes this possible.
- **All nine `*-outdated-check` scripts referenced are confirmed present in this
  repo's `composer.json`.** `_php-check-outdated-dependencies.yml` runs them with
  `eval "composer <command>"`, so a name that did not exist would fail the release.

## On the pin

Pinned to `95e2c29`, the commit that merged valkyrjaio/.github#146, rather than a
release SHA — the latest `.github` release (v26.11.0, `716065a`) predates it and
still declares the inputs required, so pinning there would reintroduce the
invalid-workflow error. This is self-correcting: `_update-workflow-refs.yml` rewrites
every `valkyrjaio/.github/…@<sha>` pin to the latest release SHA and is
filename-agnostic, so the next release normalizes it along with the rest of the repo.

## Related

Companion PR
[valkyrja-starter-app-java#49](https://github.com/valkyrjaio/valkyrja-starter-app-java/pull/49),
which has the identical history and the identical fix.
